### PR TITLE
fix: prevent infinite rebuild loop by excluding output path

### DIFF
--- a/src/hooks/tap-after-compile-to-add-dependencies.ts
+++ b/src/hooks/tap-after-compile-to-add-dependencies.ts
@@ -1,8 +1,55 @@
 import type * as rspack from '@rspack/core';
-
 import { getInfrastructureLogger } from '../infrastructure-logger';
 import type { TsCheckerRspackPluginConfig } from '../plugin-config';
 import type { TsCheckerRspackPluginState } from '../plugin-state';
+import { sep } from 'node:path';
+
+const addTrailingSep = (dir: string) => (dir.endsWith(sep) ? dir : dir + sep);
+
+const isStrictSubdir = (parent: string, child: string) => {
+  const parentDir = addTrailingSep(parent);
+  const childDir = addTrailingSep(child);
+  return parentDir !== childDir && childDir.startsWith(parentDir);
+};
+
+/**
+ * Excludes the Rspack output directory from watched dependencies
+ * when the entire project is being watched.
+ *
+ * If `writeToDisk` is enabled and the build output path is not ignored,
+ * emitted files in `output.path` may leading to an infinite rebuild loop.
+ **/
+function excludeOutputPath(
+  dependencies: NonNullable<TsCheckerRspackPluginState['lastDependencies']>,
+  compiler: rspack.Compiler
+) {
+  const isContextIncluded = dependencies.dirs.includes(compiler.context);
+  if (!isContextIncluded) {
+    return dependencies;
+  }
+
+  const outputPath =
+    typeof compiler.options.output?.path === 'string'
+      ? compiler.options.output.path
+      : compiler.outputPath;
+  if (
+    !outputPath ||
+    // If output path is not a subdir of context, no need to exclude it
+    !isStrictSubdir(compiler.context, outputPath) ||
+    // If output path is explicitly included in dirs, should not exclude it
+    dependencies.dirs.includes(outputPath)
+  ) {
+    return dependencies;
+  }
+
+  const excluded = new Set(dependencies.excluded);
+  excluded.add(outputPath);
+
+  return {
+    ...dependencies,
+    excluded: Array.from(excluded),
+  };
+}
 
 function tapAfterCompileToAddDependencies(
   compiler: rspack.Compiler,
@@ -21,9 +68,10 @@ function tapAfterCompileToAddDependencies(
 
     debug(`Got dependencies from the getDependenciesWorker.`, dependencies);
     if (dependencies) {
-      state.lastDependencies = dependencies;
+      const sanitizedDependencies = excludeOutputPath(dependencies, compiler);
+      state.lastDependencies = sanitizedDependencies;
 
-      dependencies.files.forEach((file) => {
+      sanitizedDependencies.files.forEach((file) => {
         compilation.fileDependencies.add(file);
       });
     }


### PR DESCRIPTION
## Summpary

Add logic to exclude Rspack output directory from watched dependencies when the entire project is being watched.

This prevents an infinite rebuild loop that occurs when emitted files in `output.path` trigger rebuilds. (`writeToDisk` is `true` and `dist` is not excluded in tsconfig.json)

## Linkse

resolve https://github.com/rspack-contrib/rsbuild-plugin-type-check/issues/14