### PR TITLE
fix: ensure compiler.changedFiles is the file path

### DIFF
--- a/src/watch/inclusive-node-watch-file-system.ts
+++ b/src/watch/inclusive-node-watch-file-system.ts
@@ -187,7 +187,7 @@ class InclusiveNodeWatchFileSystem implements WatchFileSystem {
         this.deletedFiles.delete(file);
         updateFilesChange(this.compiler, { changedFiles: [file] });
 
-        this.watcher?._onChange(dirToWatch, stats?.mtimeMs || stats?.ctimeMs || 1, file, 'rename');
+        this.watcher?._onChange(file, stats?.mtimeMs || stats?.ctimeMs || 1, file, 'rename');
       });
       dirWatcher.on('unlink', (file) => {
         if (this.paused) {


### PR DESCRIPTION
## Summary

Updates the parameters passed to watchpack's `_onChange` method to ensure the correct file path is reported.

This change ensures that Rspack's `compiler.changedFiles` is the file path instead of the directory path.