### PR TITLE
chore(deps): update typescript to v5.9.3 and remove rimraf

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,10 +68,9 @@
     "jest-runner": "^27.5.1",
     "mock-fs": "^5.5.0",
     "prettier": "^2.8.8",
-    "rimraf": "^3.0.2",
     "strip-ansi": "^6.0.1",
     "ts-jest": "^27.1.5",
-    "typescript": "^4.9.5"
+    "typescript": "^5.9.3"
   },
   "publishConfig": {
     "access": "public",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ importers:
         version: 27.5.1
       '@rslib/core':
         specifier: ^0.17.0
-        version: 0.17.0(typescript@4.9.5)
+        version: 0.17.0(typescript@5.9.3)
       '@rspack/core':
         specifier: ^1.6.0
         version: 1.6.0(@swc/helpers@0.5.17)
@@ -78,18 +78,15 @@ importers:
       prettier:
         specifier: ^2.8.8
         version: 2.8.8
-      rimraf:
-        specifier: ^3.0.2
-        version: 3.0.2
       strip-ansi:
         specifier: ^6.0.1
         version: 6.0.1
       ts-jest:
         specifier: ^27.1.5
-        version: 27.1.5(@babel/core@7.26.0)(@types/jest@27.5.2)(babel-jest@27.5.1(@babel/core@7.26.0))(jest@27.5.1)(typescript@4.9.5)
+        version: 27.1.5(@babel/core@7.26.0)(@types/jest@27.5.2)(babel-jest@27.5.1(@babel/core@7.26.0))(jest@27.5.1)(typescript@5.9.3)
       typescript:
-        specifier: ^4.9.5
-        version: 4.9.5
+        specifier: ^5.9.3
+        version: 5.9.3
 
   examples/babel-loader:
     devDependencies:
@@ -3747,6 +3744,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
     engines: {node: '>=4'}
@@ -5176,12 +5178,12 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@rslib/core@0.17.0(typescript@4.9.5)':
+  '@rslib/core@0.17.0(typescript@5.9.3)':
     dependencies:
       '@rsbuild/core': 1.6.0
-      rsbuild-plugin-dts: 0.17.0(@rsbuild/core@1.6.0)(typescript@4.9.5)
+      rsbuild-plugin-dts: 0.17.0(@rsbuild/core@1.6.0)(typescript@5.9.3)
     optionalDependencies:
-      typescript: 4.9.5
+      typescript: 5.9.3
     transitivePeerDependencies:
       - '@typescript/native-preview'
 
@@ -7644,12 +7646,12 @@ snapshots:
     dependencies:
       glob: 10.4.5
 
-  rsbuild-plugin-dts@0.17.0(@rsbuild/core@1.6.0)(typescript@4.9.5):
+  rsbuild-plugin-dts@0.17.0(@rsbuild/core@1.6.0)(typescript@5.9.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 1.6.0
     optionalDependencies:
-      typescript: 4.9.5
+      typescript: 5.9.3
 
   run-applescript@7.0.0: {}
 
@@ -8029,7 +8031,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  ts-jest@27.1.5(@babel/core@7.26.0)(@types/jest@27.5.2)(babel-jest@27.5.1(@babel/core@7.26.0))(jest@27.5.1)(typescript@4.9.5):
+  ts-jest@27.1.5(@babel/core@7.26.0)(@types/jest@27.5.2)(babel-jest@27.5.1(@babel/core@7.26.0))(jest@27.5.1)(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -8039,7 +8041,7 @@ snapshots:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.6.3
-      typescript: 4.9.5
+      typescript: 5.9.3
       yargs-parser: 20.2.9
     optionalDependencies:
       '@babel/core': 7.26.0
@@ -8100,6 +8102,8 @@ snapshots:
   typescript@4.9.5: {}
 
   typescript@5.7.2: {}
+
+  typescript@5.9.3: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 


### PR DESCRIPTION
## Summary

Update TypeScript dependency to latest stable version (5.9.3) and remove unused rimraf package