### PR TITLE
feat: add `defaultSeverity` configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Options for the issues filtering (`issue` option object).
 interface IssueOptions {
   include?: IssuePredicateOption;
   exclude?: IssuePredicateOption;
+  defaultSeverity?: 'auto' | 'warning' | 'error';
 }
 
 interface Issue {
@@ -140,10 +141,17 @@ type IssuePredicate = (issue: Issue) => boolean;
 type IssuePredicateOption = IssuePredicate | IssueMatch | (IssuePredicate | IssueMatch)[];
 ```
 
-| Name      | Type          | Default value | Description                                                                                                                                                |
-| --------- | ------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `include` | `IssueFilter` | `undefined`   | If `object`, defines issue properties that should be [matched](src/issue/issue-match.ts). If `function`, acts as a predicate where `issue` is an argument. |
-| `exclude` | `IssueFilter` | `undefined`   | Same as `include` but issues that match this predicate will be excluded.                                                                                   |
+| Name              | Type                             | Default value | Description                                                                                                                                                |
+| ----------------- | -------------------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `include`         | `IssueFilter`                    | `undefined`   | If `object`, defines issue properties that should be [matched](src/issue/issue-match.ts). If `function`, acts as a predicate where `issue` is an argument. |
+| `exclude`         | `IssueFilter`                    | `undefined`   | Same as `include` but issues that match this predicate will be excluded.                                                                                   |
+| `defaultSeverity` | `'auto' \| 'warning' \| 'error'` | `'auto'`      | Controls how the plugin assigns the severity of emitted issues.                                                                                            |
+
+`defaultSeverity` behavior:
+
+- `auto`: Uses the default mapping based on the TypeScript diagnostic category (`Error` → `error`, `Warning` → `warning`).
+- `warning`: Forces all issues to be emitted as warnings.
+- `error`: Forces all issues to be emitted as errors.
 
 - **Example**:
 
@@ -164,6 +172,16 @@ Exclude files under `/node_modules/` using `file:`:
 new TsCheckerRspackPlugin({
   issue: {
     exclude: [({ file = '' }) => /[\\/]some-folder[\\/]/.test(file)],
+  },
+});
+```
+
+Force all issues to be emitted as warnings and do not break the build:
+
+```js
+new TsCheckerRspackPlugin({
+  issue: {
+    defaultSeverity: 'warning',
   },
 });
 ```

--- a/src/hooks/tap-start-to-run-workers.ts
+++ b/src/hooks/tap-start-to-run-workers.ts
@@ -20,7 +20,7 @@ function tapStartToRunWorkers(
   getIssuesWorker: RpcWorker<GetIssuesWorker>,
   getDependenciesWorker: RpcWorker<GetDependenciesWorker>,
   config: TsCheckerRspackPluginConfig,
-  state: TsCheckerRspackPluginState
+  state: TsCheckerRspackPluginState,
 ) {
   const hooks = getPluginHooks(compiler);
   const { log, debug } = getInfrastructureLogger(compiler);
@@ -81,7 +81,7 @@ function tapStartToRunWorkers(
           'Calling reporter service for incremental check.',
           `  Changed files: ${JSON.stringify(filesChange.changedFiles)}`,
           `  Deleted files: ${JSON.stringify(filesChange.deletedFiles)}`,
-        ].join('\n')
+        ].join('\n'),
       );
     } else {
       log('Calling reporter service for single check.');
@@ -96,7 +96,7 @@ function tapStartToRunWorkers(
           `Aggregating with previous files change, iteration ${iteration}.`,
           `  Changed files: ${JSON.stringify(aggregatedFilesChange.changedFiles)}`,
           `  Deleted files: ${JSON.stringify(aggregatedFilesChange.deletedFiles)}`,
-        ].join('\n')
+        ].join('\n'),
       );
     }
     state.aggregatedFilesChange = aggregatedFilesChange;
@@ -115,7 +115,11 @@ function tapStartToRunWorkers(
         return issuesPool.submit(async () => {
           try {
             debug(`Running the getIssuesWorker, iteration ${iteration}.`);
-            const issues = await getIssuesWorker(aggregatedFilesChange, state.watching);
+            const issues = await getIssuesWorker(
+              aggregatedFilesChange,
+              state.watching,
+              config.issue.defaultSeverity,
+            );
             if (state.aggregatedFilesChange === aggregatedFilesChange) {
               state.aggregatedFilesChange = undefined;
             }

--- a/src/issue/issue-config.ts
+++ b/src/issue/issue-config.ts
@@ -4,9 +4,11 @@ import { createIssuePredicateFromIssueMatch } from './issue-match';
 import type { IssuePredicateOption, IssueOptions } from './issue-options';
 import type { IssuePredicate } from './issue-predicate';
 import { composeIssuePredicates, createTrivialIssuePredicate } from './issue-predicate';
+import type { IssueDefaultSeverity } from './issue-severity';
 
 interface IssueConfig {
   predicate: IssuePredicate;
+  defaultSeverity: IssueDefaultSeverity;
 }
 
 function createIssuePredicateFromOption(
@@ -42,9 +44,11 @@ function createIssueConfig(
   const exclude = options.exclude
     ? createIssuePredicateFromOption(context, options.exclude)
     : createTrivialIssuePredicate(false);
+  const defaultSeverity = options.defaultSeverity ?? 'auto';
 
   return {
     predicate: (issue) => include(issue) && !exclude(issue),
+    defaultSeverity,
   };
 }
 

--- a/src/issue/issue-options.ts
+++ b/src/issue/issue-options.ts
@@ -1,11 +1,13 @@
 import type { IssueMatch } from './issue-match';
 import type { IssuePredicate } from './issue-predicate';
+import type { IssueDefaultSeverity } from './issue-severity';
 
 type IssuePredicateOption = IssuePredicate | IssueMatch | (IssuePredicate | IssueMatch)[];
 
 interface IssueOptions {
   include?: IssuePredicateOption;
   exclude?: IssuePredicateOption;
+  defaultSeverity?: IssueDefaultSeverity;
 }
 
 export { IssueOptions, IssuePredicateOption };

--- a/src/issue/issue-severity.ts
+++ b/src/issue/issue-severity.ts
@@ -1,15 +1,14 @@
-type IssueSeverity = 'error' | 'warning';
+export type IssueSeverity = 'error' | 'warning';
+export type IssueDefaultSeverity = IssueSeverity | 'auto';
 
-function isIssueSeverity(value: unknown): value is IssueSeverity {
+export function isIssueSeverity(value: unknown): value is IssueSeverity {
   return ['error', 'warning'].includes(value as IssueSeverity);
 }
 
-function compareIssueSeverities(severityA: IssueSeverity, severityB: IssueSeverity) {
+export function compareIssueSeverities(severityA: IssueSeverity, severityB: IssueSeverity) {
   const [priorityA, priorityB] = [severityA, severityB].map((severity) =>
-    ['warning' /* 0 */, 'error' /* 1 */].indexOf(severity)
+    ['warning' /* 0 */, 'error' /* 1 */].indexOf(severity),
   );
 
   return Math.sign(priorityB - priorityA);
 }
-
-export { IssueSeverity, isIssueSeverity, compareIssueSeverities };

--- a/src/typescript/worker/get-issues-worker.ts
+++ b/src/typescript/worker/get-issues-worker.ts
@@ -1,5 +1,5 @@
 import type { FilesChange } from '../../files-change';
-import type { Issue } from '../../issue';
+import type { Issue, IssueDefaultSeverity } from '../../issue';
 import { exposeRpc } from '../../rpc';
 
 import { invalidateArtifacts, registerArtifacts } from './lib/artifacts';
@@ -29,7 +29,11 @@ import { dumpTracingLegendIfNeeded } from './lib/tracing';
 import { invalidateTsBuildInfo } from './lib/tsbuildinfo';
 import { config } from './lib/worker-config';
 
-const getIssuesWorker = async (change: FilesChange, watching: boolean): Promise<Issue[]> => {
+const getIssuesWorker = async (
+  change: FilesChange,
+  watching: boolean,
+  defaultSeverity: IssueDefaultSeverity,
+): Promise<Issue[]> => {
   system.invalidateCache();
 
   if (didConfigFileChanged(change)) {
@@ -57,7 +61,7 @@ const getIssuesWorker = async (change: FilesChange, watching: boolean): Promise<
   registerArtifacts();
   enablePerformanceIfNeeded();
 
-  const parseConfigIssues = getParseConfigIssues();
+  const parseConfigIssues = getParseConfigIssues(defaultSeverity);
   if (parseConfigIssues.length) {
     // report config parse issues and exit
     return parseConfigIssues;
@@ -84,7 +88,7 @@ const getIssuesWorker = async (change: FilesChange, watching: boolean): Promise<
   await system.waitForQueued();
 
   // retrieve all collected diagnostics as normalized issues
-  const issues = getIssues();
+  const issues = getIssues(defaultSeverity);
 
   dumpTracingLegendIfNeeded();
   printPerformanceMeasuresIfNeeded();

--- a/src/typescript/worker/lib/config.ts
+++ b/src/typescript/worker/lib/config.ts
@@ -4,7 +4,7 @@ import type * as ts from 'typescript';
 
 import type { FilesChange } from '../../../files-change';
 import type { FilesMatch } from '../../../files-match';
-import type { Issue } from '../../../issue';
+import type { Issue, IssueDefaultSeverity } from '../../../issue';
 import { forwardSlash } from '../../../utils/path/forward-slash';
 import type { TypeScriptConfigOverwrite } from '../../type-script-config-overwrite';
 
@@ -84,25 +84,25 @@ function applyConfigOverwrite(
 
 export function parseConfig(
   configFileName: string,
-  configFileContext: string
+  configFileContext: string,
 ): ts.ParsedCommandLine {
   const configFilePath = forwardSlash(configFileName);
 
   const { config: baseConfig, error: readConfigError } = typescript.readConfigFile(
     configFilePath,
-    parseConfigFileHost.readFile
+    parseConfigFileHost.readFile,
   );
 
   const overwrittenConfig = applyConfigOverwrite(
     baseConfig || {},
     getImplicitConfigOverwrite(),
-    getUserProvidedConfigOverwrite()
+    getUserProvidedConfigOverwrite(),
   );
 
   const parsedConfigFile = typescript.parseJsonConfigFileContent(
     overwrittenConfig,
     parseConfigFileHost,
-    configFileContext
+    configFileContext,
   );
 
   return {
@@ -115,8 +115,8 @@ export function parseConfig(
   };
 }
 
-export function getParseConfigIssues(): Issue[] {
-  const issues = createIssuesFromDiagnostics(parseConfigDiagnostics);
+export function getParseConfigIssues(defaultSeverity: IssueDefaultSeverity): Issue[] {
+  const issues = createIssuesFromDiagnostics(parseConfigDiagnostics, defaultSeverity);
 
   issues.forEach((issue) => {
     if (!issue.file) {
@@ -168,13 +168,13 @@ export function didConfigFileChanged({ changedFiles = [], deletedFiles = [] }: F
 
 export function didDependenciesProbablyChanged(
   dependencies: FilesMatch,
-  { changedFiles = [], deletedFiles = [] }: FilesChange
+  { changedFiles = [], deletedFiles = [] }: FilesChange,
 ) {
   const didSomeDependencyHasBeenAdded = changedFiles.some(
-    (changeFile) => !dependencies.files.includes(changeFile)
+    (changeFile) => !dependencies.files.includes(changeFile),
   );
   const didSomeDependencyHasBeenDeleted = deletedFiles.some((deletedFile) =>
-    dependencies.files.includes(deletedFile)
+    dependencies.files.includes(deletedFile),
   );
 
   return didSomeDependencyHasBeenAdded || didSomeDependencyHasBeenDeleted;

--- a/test/e2e/with-rsbuild/index.test.ts
+++ b/test/e2e/with-rsbuild/index.test.ts
@@ -32,7 +32,7 @@ const createRsbuild = async (config: CreateRsbuildOptions) => {
           provider: webpackProvider,
           plugins: [pluginSwc()],
         }
-      : {}
+      : {},
   );
 
   return await baseCreateRsbuild({
@@ -60,8 +60,8 @@ test('should throw error when exist type errors', async () => {
 
   expect(
     logs.find((log) =>
-      log.includes(`Argument of type 'string' is not assignable to parameter of type 'number'.`)
-    )
+      log.includes(`Argument of type 'string' is not assignable to parameter of type 'number'.`),
+    ),
   ).toBeTruthy();
 
   restore();
@@ -92,8 +92,8 @@ test('should throw error when exist type errors in dev mode', async ({ page }) =
 
   expect(
     logs.find((log) =>
-      log.includes(`Argument of type 'string' is not assignable to parameter of type 'number'.`)
-    )
+      log.includes(`Argument of type 'string' is not assignable to parameter of type 'number'.`),
+    ),
   ).toBeTruthy();
 
   restore();
@@ -118,6 +118,32 @@ test('should not throw error when the file is excluded', async () => {
   });
 
   await expect(rsbuild.build()).resolves.toBeTruthy();
+});
+
+test('should downgrade type errors to warnings when defaultSeverity is warning', async () => {
+  const rsbuild = await createRsbuild({
+    rsbuildConfig: {
+      tools: {
+        rspack: {
+          plugins: [
+            new TsCheckerRspackPlugin({
+              async: false,
+              issue: {
+                defaultSeverity: 'warning',
+              },
+            }),
+          ],
+        },
+      },
+    },
+  });
+
+  const { stats } = await rsbuild.build();
+  const statsJson = stats?.toJson('errors-warnings') || {};
+  expect(statsJson.warnings?.[0]?.message).toContain(
+    `Argument of type 'string' is not assignable to parameter of type 'number'`,
+  );
+  expect(statsJson.errors?.length).toEqual(0);
 });
 
 test('should not throw error when the file is excluded by code', async () => {


### PR DESCRIPTION
## Summary

- add `defaultSeverity` option to control issue severity mapping
- add documentation for the new configuration option

## Related

- https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/issues/232
- https://github.com/facebook/create-react-app/blob/main/packages/react-dev-utils/ForkTsCheckerWarningWebpackPlugin.js
- https://github.com/web-infra-dev/rsbuild/pull/6671