### PR TITLE
fix: enhance IPC error handling

### DIFF
--- a/src/rpc/expose-rpc.ts
+++ b/src/rpc/expose-rpc.ts
@@ -4,7 +4,7 @@ import type { RpcMessage } from './types';
 function isClosedIpcChannelError(error: unknown): boolean {
   if (typeof error === 'object' && error !== null && 'code' in error) {
     const CLOSED_IPC_ERROR_CODES = new Set(['ERR_IPC_CHANNEL_CLOSED', 'EPIPE']);
-    return Boolean(CLOSED_IPC_ERROR_CODES.has(error.code as string));
+    return CLOSED_IPC_ERROR_CODES.has(error.code as string);
   }
   return false;
 }


### PR DESCRIPTION
## Summary

Updated the error handling logic in `exposeRpc` to log a warning and skip further processing if a closed IPC channel error is detected, preventing unnecessary error reporting when the parent process has exited.

## Before

<img width="1061" height="353" alt="Screenshot 2025-12-16 at 16 38 13" src="https://github.com/user-attachments/assets/aaa20650-7c60-42af-897a-e1ec669b98d2" />

## After

<img width="1096" height="197" alt="Screenshot 2025-12-16 at 16 36 42" src="https://github.com/user-attachments/assets/c1a4fb58-0d01-4161-8fe4-bc6767ad7253" />
