### PR TITLE
fix: replace webpack references with Rspack

### DIFF
--- a/src/formatter/index.ts
+++ b/src/formatter/index.ts
@@ -1,6 +1,6 @@
 export * from './formatter';
 export * from './basic-formatter';
 export * from './code-frame-formatter';
-export * from './webpack-formatter';
+export * from './rspack-formatter';
 export * from './formatter-options';
 export * from './formatter-config';

--- a/src/formatter/rspack-formatter.ts
+++ b/src/formatter/rspack-formatter.ts
@@ -9,9 +9,9 @@ import { relativeToContext } from '../utils/path/relative-to-context';
 
 import type { Formatter, FormatterPathType } from './formatter';
 
-function createWebpackFormatter(formatter: Formatter, pathType: FormatterPathType): Formatter {
-  // mimics webpack error formatter
-  return function webpackFormatter(issue) {
+function createRspackFormatter(formatter: Formatter, pathType: FormatterPathType): Formatter {
+  // mimics Rspack error formatter
+  return function rspackFormatter(issue) {
     const color = issue.severity === 'warning' ? pc.yellow : pc.red;
 
     const severity = issue.severity.toUpperCase();
@@ -33,4 +33,4 @@ function createWebpackFormatter(formatter: Formatter, pathType: FormatterPathTyp
   };
 }
 
-export { createWebpackFormatter };
+export { createRspackFormatter };

--- a/src/hooks/tap-after-compile-to-get-issues.ts
+++ b/src/hooks/tap-after-compile-to-get-issues.ts
@@ -2,7 +2,7 @@ import type * as rspack from '@rspack/core';
 
 import { getInfrastructureLogger } from '../infrastructure-logger';
 import type { Issue } from '../issue';
-import { IssueWebpackError } from '../issue/issue-webpack-error';
+import { IssueRspackError } from '../issue/issue-rspack-error';
 import type { TsCheckerRspackPluginConfig } from '../plugin-config';
 import { getPluginHooks } from '../plugin-hooks';
 import type { TsCheckerRspackPluginState } from '../plugin-state';
@@ -44,7 +44,7 @@ function tapAfterCompileToGetIssues(
     issues = hooks.issues.call(issues, compilation);
 
     issues.forEach((issue) => {
-      const error = new IssueWebpackError(
+      const error = new IssueRspackError(
         config.formatter.format(issue),
         config.formatter.pathType,
         issue

--- a/src/hooks/tap-after-environment-to-patch-watching.ts
+++ b/src/hooks/tap-after-environment-to-patch-watching.ts
@@ -14,7 +14,7 @@ function tapAfterEnvironmentToPatchWatching(
   compiler.hooks.afterEnvironment.tap('TsCheckerRspackPlugin', () => {
     const watchFileSystem = compiler.watchFileSystem;
     if (watchFileSystem) {
-      debug("Overwriting webpack's watch file system.");
+      debug("Overwriting Rspack's watch file system.");
       // wrap original watch file system
       compiler.watchFileSystem = new InclusiveNodeWatchFileSystem(
         // we use some internals here

--- a/src/hooks/tap-done-to-async-get-issues.ts
+++ b/src/hooks/tap-done-to-async-get-issues.ts
@@ -2,10 +2,10 @@ import pc from 'picocolors';
 import type * as rspack from '@rspack/core';
 
 import { statsFormatter } from '../formatter/stats-formatter';
-import { createWebpackFormatter } from '../formatter/webpack-formatter';
+import { createRspackFormatter } from '../formatter/rspack-formatter';
 import { getInfrastructureLogger } from '../infrastructure-logger';
 import type { Issue } from '../issue';
-import { IssueWebpackError } from '../issue/issue-webpack-error';
+import { IssueRspackError } from '../issue/issue-rspack-error';
 import type { TsCheckerRspackPluginConfig } from '../plugin-config';
 import { getPluginHooks } from '../plugin-hooks';
 import type { TsCheckerRspackPluginState } from '../plugin-state';
@@ -34,7 +34,7 @@ function tapDoneToAsyncGetIssues(
         hooks.waiting.call(stats.compilation);
         config.logger.log(pc.cyan('[type-check] in progress...'));
       } else {
-        // wait 10ms to log issues after webpack stats
+        // wait 10ms to log issues after Rspack stats
         await wait(10);
       }
 
@@ -59,10 +59,10 @@ function tapDoneToAsyncGetIssues(
     // modify list of issues in the plugin hooks
     issues = hooks.issues.call(issues, stats.compilation);
 
-    const formatter = createWebpackFormatter(config.formatter.format, config.formatter.pathType);
+    const formatter = createRspackFormatter(config.formatter.format, config.formatter.pathType);
 
     if (issues.length) {
-      // follow webpack's approach - one process.write to stderr with all errors and warnings
+      // follow Rspack's approach - one process.write to stderr with all errors and warnings
       config.logger.error(issues.map((issue) => formatter(issue)).join('\n'));
     }
 
@@ -73,7 +73,7 @@ function tapDoneToAsyncGetIssues(
     // skip reporting if there are no issues, to avoid an extra hot reload
     if (issues.length && state.DevServerDoneTap) {
       issues.forEach((issue) => {
-        const error = new IssueWebpackError(
+        const error = new IssueRspackError(
           config.formatter.format(issue),
           config.formatter.pathType,
           issue

--- a/src/issue/issue-rspack-error.ts
+++ b/src/issue/issue-rspack-error.ts
@@ -6,7 +6,7 @@ import { relativeToContext } from '../utils/path/relative-to-context';
 import type { Issue } from './issue';
 import { formatIssueLocation } from './issue-location';
 
-class IssueWebpackError extends Error {
+class IssueRspackError extends Error {
   readonly hideStack = true;
 
   file?: string;
@@ -32,4 +32,4 @@ class IssueWebpackError extends Error {
   }
 }
 
-export { IssueWebpackError };
+export { IssueRspackError };

--- a/src/typescript/type-script-support.ts
+++ b/src/typescript/type-script-support.ts
@@ -9,7 +9,7 @@ function assertTypeScriptSupport(config: TypeScriptWorkerConfig) {
   try {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     typescriptVersion = require(config.typescriptPath).version;
-  } catch (error) {
+  } catch {
     // silent catch
   }
 
@@ -23,9 +23,9 @@ function assertTypeScriptSupport(config: TypeScriptWorkerConfig) {
     throw new Error(
       [
         `Cannot find the "${config.configFile}" file.`,
-        `Please check webpack and TsCheckerRspackPlugin configuration.`,
+        `Please check Rspack and TsCheckerRspackPlugin configuration.`,
         `Possible errors:`,
-        '  - wrong `context` directory in webpack configuration (if `configFile` is not set or is a relative path in the fork plugin configuration)',
+        '  - wrong `context` directory in Rspack configuration (if `configFile` is not set or is a relative path in the fork plugin configuration)',
         '  - wrong `typescript.configFile` path in the plugin configuration (should be a relative or absolute path)',
       ].join(os.EOL)
     );

--- a/src/typescript/worker/lib/system.ts
+++ b/src/typescript/worker/lib/system.ts
@@ -24,13 +24,13 @@ export interface ControlledTypeScriptSystem extends ts.System {
     path: string,
     callback: ts.FileWatcherCallback,
     pollingInterval?: number,
-    options?: ts.WatchOptions
+    options?: ts.WatchOptions,
   ): ts.FileWatcher;
   watchDirectory(
     path: string,
     callback: ts.DirectoryWatcherCallback,
     recursive?: boolean,
-    options?: ts.WatchOptions
+    options?: ts.WatchOptions,
   ): ts.FileWatcher;
   getModifiedTime(path: string | undefined): Date | undefined;
   setModifiedTime(path: string, time: Date): void;
@@ -109,7 +109,7 @@ export const system: ControlledTypeScriptSystem = {
       .filter(
         (dirent) =>
           dirent.isDirectory() ||
-          (dirent.isSymbolicLink() && system.directoryExists(join(path, dirent.name)))
+          (dirent.isSymbolicLink() && system.directoryExists(join(path, dirent.name))),
       )
       .map((dirent) => dirent.name);
   },
@@ -135,12 +135,12 @@ export const system: ControlledTypeScriptSystem = {
   watchDirectory(
     path: string,
     callback: ts.DirectoryWatcherCallback,
-    recursive = false
+    recursive = false,
   ): ts.FileWatcher {
     return createWatcher(
       recursive ? recursiveDirectoryWatcherCallbacksMap : directoryWatcherCallbacksMap,
       path,
-      callback
+      callback,
     );
   },
   // use immediate instead of timeout to avoid waiting 250ms for batching files changes
@@ -206,7 +206,7 @@ export const system: ControlledTypeScriptSystem = {
 function createWatcher<TCallback>(
   watchersMap: Map<string, TCallback[]>,
   path: string,
-  callback: TCallback
+  callback: TCallback,
 ) {
   const normalizedPath = normalizeAndResolvePath(path);
   const watchers = watchersMap.get(normalizedPath) || [];
@@ -230,7 +230,7 @@ function createWatcher<TCallback>(
 function invokeFileWatchers(path: string, event: ts.FileWatcherEventKind) {
   const normalizedPath = normalizeAndResolvePath(path);
   if (normalizedPath.endsWith('.js')) {
-    // trigger relevant .d.ts file watcher - handles the case, when we have webpack watcher
+    // trigger relevant .d.ts file watcher - handles the case, when we have Rspack watcher
     // that points to a symlinked package
     invokeFileWatchers(normalizedPath.slice(0, -3) + '.d.ts', event);
   }
@@ -238,9 +238,9 @@ function invokeFileWatchers(path: string, event: ts.FileWatcherEventKind) {
   const fileWatcherCallbacks = fileWatcherCallbacksMap.get(normalizedPath);
   if (fileWatcherCallbacks) {
     // typescript expects normalized paths with posix forward slash
-    fileWatcherCallbacks.forEach((fileWatcherCallback) =>
-      fileWatcherCallback(forwardSlash(normalizedPath), event)
-    );
+    fileWatcherCallbacks.forEach((fileWatcherCallback) => {
+      fileWatcherCallback(forwardSlash(normalizedPath), event);
+    });
   }
 }
 
@@ -254,9 +254,9 @@ function invokeDirectoryWatchers(path: string) {
 
   const directoryWatcherCallbacks = directoryWatcherCallbacksMap.get(directory);
   if (directoryWatcherCallbacks) {
-    directoryWatcherCallbacks.forEach((directoryWatcherCallback) =>
-      directoryWatcherCallback(forwardSlash(normalizedPath))
-    );
+    directoryWatcherCallbacks.forEach((directoryWatcherCallback) => {
+      directoryWatcherCallback(forwardSlash(normalizedPath));
+    });
   }
 
   recursiveDirectoryWatcherCallbacksMap.forEach(
@@ -266,11 +266,11 @@ function invokeDirectoryWatchers(path: string) {
         (directory.startsWith(watchedDirectory) &&
           forwardSlash(directory)[watchedDirectory.length] === '/')
       ) {
-        recursiveDirectoryWatcherCallbacks.forEach((recursiveDirectoryWatcherCallback) =>
-          recursiveDirectoryWatcherCallback(forwardSlash(normalizedPath))
-        );
+        recursiveDirectoryWatcherCallbacks.forEach((recursiveDirectoryWatcherCallback) => {
+          recursiveDirectoryWatcherCallback(forwardSlash(normalizedPath));
+        });
       }
-    }
+    },
   );
 }
 

--- a/test/unit/formatter/webpack-formatter.spec.ts
+++ b/test/unit/formatter/webpack-formatter.spec.ts
@@ -2,7 +2,7 @@ import os from 'os';
 import { join } from 'path';
 
 import type { Formatter } from 'src/formatter';
-import { createBasicFormatter, createWebpackFormatter } from 'src/formatter';
+import { createBasicFormatter, createRspackFormatter } from 'src/formatter';
 import type { Issue } from 'src/issue';
 import { forwardSlash } from 'src/utils/path/forward-slash';
 
@@ -28,8 +28,8 @@ describe('formatter/webpack-formatter', () => {
   let absoluteFormatter: Formatter;
 
   beforeEach(() => {
-    relativeFormatter = createWebpackFormatter(createBasicFormatter(), 'relative');
-    absoluteFormatter = createWebpackFormatter(createBasicFormatter(), 'absolute');
+    relativeFormatter = createRspackFormatter(createBasicFormatter(), 'relative');
+    absoluteFormatter = createRspackFormatter(createBasicFormatter(), 'absolute');
   });
 
   it('decorates existing relativeFormatter', () => {

--- a/test/unit/typescript/type-script-support.spec.ts
+++ b/test/unit/typescript/type-script-support.spec.ts
@@ -46,9 +46,9 @@ describe('typescript/type-script-support', () => {
     expect(() => assertTypeScriptSupport(configuration)).toThrowError(
       [
         `Cannot find the "./tsconfig.json" file.`,
-        `Please check webpack and TsCheckerRspackPlugin configuration.`,
+        `Please check Rspack and TsCheckerRspackPlugin configuration.`,
         `Possible errors:`,
-        '  - wrong `context` directory in webpack configuration (if `configFile` is not set or is a relative path in the fork plugin configuration)',
+        '  - wrong `context` directory in Rspack configuration (if `configFile` is not set or is a relative path in the fork plugin configuration)',
         '  - wrong `typescript.configFile` path in the plugin configuration (should be a relative or absolute path)',
       ].join(os.EOL)
     );


### PR DESCRIPTION
## Summary

Renaming classes, functions, files, and error messages to use "Rspack" instead of "webpack"