### PR TITLE
chore: update import statements to use node prefix

### DIFF
--- a/src/formatter/code-frame-formatter.ts
+++ b/src/formatter/code-frame-formatter.ts
@@ -1,4 +1,4 @@
-import os from 'os';
+import os from 'node:os';
 
 import { codeFrameColumns } from '@babel/code-frame';
 import fs from 'node:fs';

--- a/src/formatter/rspack-formatter.ts
+++ b/src/formatter/rspack-formatter.ts
@@ -1,5 +1,5 @@
-import os from 'os';
-import path from 'path';
+import os from 'node:os';
+import path from 'node:path';
 
 import pc from 'picocolors';
 

--- a/src/issue/issue-match.ts
+++ b/src/issue/issue-match.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { minimatch } from 'minimatch';
 
 import { forwardSlash } from '../utils/path/forward-slash';

--- a/src/issue/issue-rspack-error.ts
+++ b/src/issue/issue-rspack-error.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import type { FormatterPathType } from '../formatter';
 import { forwardSlash } from '../utils/path/forward-slash';
 import { relativeToContext } from '../utils/path/relative-to-context';

--- a/src/plugin-pools.ts
+++ b/src/plugin-pools.ts
@@ -1,4 +1,4 @@
-import * as os from 'os';
+import * as os from 'node:os';
 
 import type { Pool } from './utils/async/pool';
 import { createPool } from './utils/async/pool';

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import type * as rspack from '@rspack/core';
 

--- a/src/rpc/rpc-worker.ts
+++ b/src/rpc/rpc-worker.ts
@@ -1,6 +1,6 @@
-import * as child_process from 'child_process';
-import type { ChildProcess, ForkOptions } from 'child_process';
-import * as process from 'process';
+import * as child_process from 'node:child_process';
+import type { ChildProcess, ForkOptions } from 'node:child_process';
+import * as process from 'node:process';
 
 import type { RpcMethod, RpcRemoteMethod } from './types';
 import { wrapRpc } from './wrap-rpc';

--- a/src/rpc/wrap-rpc.ts
+++ b/src/rpc/wrap-rpc.ts
@@ -1,4 +1,4 @@
-import type { ChildProcess } from 'child_process';
+import type { ChildProcess } from 'node:child_process';
 
 import { createControlledPromise } from '../utils/async/controlled-promise';
 

--- a/src/typescript/type-script-support.ts
+++ b/src/typescript/type-script-support.ts
@@ -1,4 +1,4 @@
-import os from 'os';
+import os from 'node:os';
 import fs from 'node:fs';
 
 import type { TypeScriptWorkerConfig } from './type-script-worker-config';

--- a/src/typescript/type-script-worker-config.ts
+++ b/src/typescript/type-script-worker-config.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import type * as rspack from '@rspack/core';
 

--- a/src/typescript/worker/lib/artifacts.ts
+++ b/src/typescript/worker/lib/artifacts.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import type * as ts from 'typescript';
 

--- a/src/typescript/worker/lib/config.ts
+++ b/src/typescript/worker/lib/config.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import type * as ts from 'typescript';
 

--- a/src/typescript/worker/lib/dependencies.ts
+++ b/src/typescript/worker/lib/dependencies.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import type * as ts from 'typescript';
 

--- a/src/typescript/worker/lib/diagnostics.ts
+++ b/src/typescript/worker/lib/diagnostics.ts
@@ -1,4 +1,4 @@
-import * as os from 'os';
+import * as os from 'node:os';
 
 import type * as ts from 'typescript';
 

--- a/src/typescript/worker/lib/file-system/file-system.ts
+++ b/src/typescript/worker/lib/file-system/file-system.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line node/no-unsupported-features/node-builtins
-import type { Dirent, Stats } from 'fs';
+import type { Dirent, Stats } from 'node:fs';
 
 /**
  * Interface to abstract file system implementation details.

--- a/src/typescript/worker/lib/file-system/mem-file-system.ts
+++ b/src/typescript/worker/lib/file-system/mem-file-system.ts
@@ -1,5 +1,5 @@
-import type { Dirent, Stats } from 'fs';
-import { dirname } from 'path';
+import type { Dirent, Stats } from 'node:fs';
+import { dirname } from 'node:path';
 
 import { fs as mem } from 'memfs';
 

--- a/src/typescript/worker/lib/file-system/real-file-system.ts
+++ b/src/typescript/worker/lib/file-system/real-file-system.ts
@@ -1,5 +1,5 @@
-import type { Dirent, Stats } from 'fs';
-import { dirname, basename, join, normalize } from 'path';
+import type { Dirent, Stats } from 'node:fs';
+import { dirname, basename, join, normalize } from 'node:path';
 
 import fs from 'node:fs';
 

--- a/src/typescript/worker/lib/system.ts
+++ b/src/typescript/worker/lib/system.ts
@@ -1,4 +1,4 @@
-import { dirname, join } from 'path';
+import { dirname, join } from 'node:path';
 
 import type * as ts from 'typescript';
 

--- a/src/typescript/worker/lib/tsbuildinfo.ts
+++ b/src/typescript/worker/lib/tsbuildinfo.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import type * as ts from 'typescript';
 

--- a/src/utils/path/forward-slash.ts
+++ b/src/utils/path/forward-slash.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 /**
  * Replaces backslashes with one forward slash

--- a/src/utils/path/is-inside-another-path.ts
+++ b/src/utils/path/is-inside-another-path.ts
@@ -1,4 +1,4 @@
-import { relative, isAbsolute } from 'path';
+import { relative, isAbsolute } from 'node:path';
 
 function isInsideAnotherPath(parent: string, directory: string): boolean {
   const relativePart = relative(parent, directory);

--- a/src/utils/path/relative-to-context.ts
+++ b/src/utils/path/relative-to-context.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { forwardSlash } from './forward-slash';
 

--- a/src/watch/inclusive-node-watch-file-system.ts
+++ b/src/watch/inclusive-node-watch-file-system.ts
@@ -1,4 +1,4 @@
-import path, { extname } from 'path';
+import path, { extname } from 'node:path';
 
 import type { FSWatcher } from 'chokidar';
 import chokidar from 'chokidar';

--- a/src/watch/watch-file-system.ts
+++ b/src/watch/watch-file-system.ts
@@ -1,4 +1,4 @@
-import type { EventEmitter } from 'events';
+import type { EventEmitter } from 'node:events';
 
 import type * as rspack from '@rspack/core';
 

--- a/test/e2e-legacy/driver/webpack-dev-server-driver.ts
+++ b/test/e2e-legacy/driver/webpack-dev-server-driver.ts
@@ -1,4 +1,4 @@
-import type { ChildProcess } from 'child_process';
+import type { ChildProcess } from 'node:child_process';
 
 import stripAnsi from 'strip-ansi';
 

--- a/test/e2e-legacy/fixtures/typescript-basic/rspack.config.js
+++ b/test/e2e-legacy/fixtures/typescript-basic/rspack.config.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('node:path');
 const { TsCheckerRspackPlugin } = require('ts-checker-rspack-plugin');
 
 module.exports = {

--- a/test/e2e-legacy/fixtures/typescript-monorepo/rspack.config.js
+++ b/test/e2e-legacy/fixtures/typescript-monorepo/rspack.config.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('node:path');
 const { TsCheckerRspackPlugin } = require('ts-checker-rspack-plugin');
 
 module.exports = {

--- a/test/e2e-legacy/jest.setup.ts
+++ b/test/e2e-legacy/jest.setup.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { createSandbox, packLocalPackage } from 'karton';
 import type { Sandbox } from 'karton';

--- a/test/e2e-legacy/out-of-memory-and-cosmiconfig.spec.ts
+++ b/test/e2e-legacy/out-of-memory-and-cosmiconfig.spec.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { createProcessDriver } from 'karton';
 

--- a/test/e2e-legacy/type-definitions.spec.ts
+++ b/test/e2e-legacy/type-definitions.spec.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 describe('Type Definitions', () => {
   it('provides valid type definitions', async () => {

--- a/test/e2e-legacy/type-script-config.spec.ts
+++ b/test/e2e-legacy/type-script-config.spec.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import type { WebpackDevServerDriver } from './driver/webpack-dev-server-driver';
 import { createWebpackDevServerDriver } from './driver/webpack-dev-server-driver';

--- a/test/e2e-legacy/type-script-context-option.spec.ts
+++ b/test/e2e-legacy/type-script-context-option.spec.ts
@@ -1,5 +1,5 @@
-import os from 'os';
-import path from 'path';
+import os from 'node:os';
+import path from 'node:path';
 
 import { createWebpackDevServerDriver } from './driver/webpack-dev-server-driver';
 

--- a/test/e2e-legacy/type-script-formatter-option.spec.ts
+++ b/test/e2e-legacy/type-script-formatter-option.spec.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { createWebpackDevServerDriver } from './driver/webpack-dev-server-driver';
 

--- a/test/e2e-legacy/type-script-solution-builder-api.spec.ts
+++ b/test/e2e-legacy/type-script-solution-builder-api.spec.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import semver from 'semver';
 

--- a/test/e2e-legacy/type-script-tracing.spec.ts
+++ b/test/e2e-legacy/type-script-tracing.spec.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { extractWebpackErrors } from './driver/webpack-errors-extractor';
 

--- a/test/e2e-legacy/type-script-watch-api.spec.ts
+++ b/test/e2e-legacy/type-script-watch-api.spec.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import semver from 'semver';
 

--- a/test/e2e-legacy/webpack-inclusive-watcher.spec.ts
+++ b/test/e2e-legacy/webpack-inclusive-watcher.spec.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { createProcessDriver } from 'karton';
 

--- a/test/e2e-legacy/webpack-node-api.spec.ts
+++ b/test/e2e-legacy/webpack-node-api.spec.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 describe('Webpack Node Api', () => {
   it.each([{ webpack: '5.11.0' }, { webpack: '^5.11.0' }])(

--- a/test/e2e-legacy/webpack-production-build.spec.ts
+++ b/test/e2e-legacy/webpack-production-build.spec.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import stripAnsi from 'strip-ansi';
 

--- a/test/unit/formatter/code-frame-formatter.spec.ts
+++ b/test/unit/formatter/code-frame-formatter.spec.ts
@@ -1,4 +1,4 @@
-import * as os from 'os';
+import * as os from 'node:os';
 
 import mockFs from 'mock-fs';
 import { createCodeFrameFormatter } from 'src/formatter';

--- a/test/unit/formatter/formatter-config.spec.ts
+++ b/test/unit/formatter/formatter-config.spec.ts
@@ -1,4 +1,4 @@
-import os from 'os';
+import os from 'node:os';
 
 import mockFs from 'mock-fs';
 import type { FormatterOptions } from 'src/formatter';

--- a/test/unit/formatter/webpack-formatter.spec.ts
+++ b/test/unit/formatter/webpack-formatter.spec.ts
@@ -1,5 +1,5 @@
-import os from 'os';
-import { join } from 'path';
+import os from 'node:os';
+import { join } from 'node:path';
 
 import type { Formatter } from 'src/formatter';
 import { createBasicFormatter, createRspackFormatter } from 'src/formatter';

--- a/test/unit/rpc/wrap-rpc.spec.ts
+++ b/test/unit/rpc/wrap-rpc.spec.ts
@@ -1,4 +1,4 @@
-import type { ChildProcess } from 'child_process';
+import type { ChildProcess } from 'node:child_process';
 
 import { RpcExitError, wrapRpc } from '../../../src/rpc';
 

--- a/test/unit/typescript/type-script-support.spec.ts
+++ b/test/unit/typescript/type-script-support.spec.ts
@@ -1,4 +1,4 @@
-import os from 'os';
+import os from 'node:os';
 
 import type { TypeScriptWorkerConfig } from 'src/typescript/type-script-worker-config';
 

--- a/test/unit/typescript/type-script-worker-config.spec.ts
+++ b/test/unit/typescript/type-script-worker-config.spec.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import type { TypeScriptWorkerConfig } from 'src/typescript/type-script-worker-config';
 import type { TypeScriptWorkerOptions } from 'src/typescript/type-script-worker-options';

--- a/test/unit/utils/path/is-inside-another-path-unix.spec.ts
+++ b/test/unit/utils/path/is-inside-another-path-unix.spec.ts
@@ -1,6 +1,6 @@
 import { isInsideAnotherPath } from '../../../../src/utils/path/is-inside-another-path';
 
-jest.mock('path', () => jest.requireActual('path').posix);
+jest.mock('node:path', () => jest.requireActual('node:path').posix);
 
 const unixTests: [string, string, boolean][] = [
   // Identical

--- a/test/unit/utils/path/is-inside-another-path-windows.spec.ts
+++ b/test/unit/utils/path/is-inside-another-path-windows.spec.ts
@@ -1,6 +1,6 @@
 import { isInsideAnotherPath } from '../../../../src/utils/path/is-inside-another-path';
 
-jest.mock('path', () => jest.requireActual('path').win32);
+jest.mock('node:path', () => jest.requireActual('node:path').win32);
 
 const windowsTests: [string, string, boolean][] = [
   // subfolder


### PR DESCRIPTION
Updates all imports of Node.js core modules throughout the codebase to use the explicit `node:` protocol prefix.