### PR TITLE
feat: set reportDiagnostic to solution builder

### DIFF
--- a/test/e2e/with-rsbuild/__fixtures__/solution-builder/a/src/index.ts
+++ b/test/e2e/with-rsbuild/__fixtures__/solution-builder/a/src/index.ts
@@ -1,0 +1,1 @@
+export const a = 1;

--- a/test/e2e/with-rsbuild/__fixtures__/solution-builder/a/tsconfig.json
+++ b/test/e2e/with-rsbuild/__fixtures__/solution-builder/a/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "target": "ES2021",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "strict": true,
+    "types": []
+  },
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../b"
+    }
+  ]
+}

--- a/test/e2e/with-rsbuild/__fixtures__/solution-builder/b/src/index.ts
+++ b/test/e2e/with-rsbuild/__fixtures__/solution-builder/b/src/index.ts
@@ -1,0 +1,1 @@
+export const b = 2;

--- a/test/e2e/with-rsbuild/__fixtures__/solution-builder/b/tsconfig.json
+++ b/test/e2e/with-rsbuild/__fixtures__/solution-builder/b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "target": "ES2021",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "strict": true,
+    "types": []
+  },
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../a"
+    }
+  ]
+}

--- a/test/e2e/with-rsbuild/index.test.ts
+++ b/test/e2e/with-rsbuild/index.test.ts
@@ -165,3 +165,29 @@ test('should not throw error when the file is excluded by code', async () => {
 
   await expect(rsbuild.build()).resolves.toBeTruthy();
 });
+
+test('should host diagnostics in SolutionBuilder (e.g. TS6202 for circular project references)', async () => {
+  const { logs, restore } = proxyConsole();
+
+  const rsbuild = await createRsbuild({
+    rsbuildConfig: {
+      tools: {
+        rspack: {
+          plugins: [
+            new TsCheckerRspackPlugin({
+              typescript: {
+                build: true,
+                configFile: './tsconfig.circular.json',
+              },
+            }),
+          ],
+        },
+      },
+    },
+  });
+
+  await expect(rsbuild.build()).rejects.toThrowError('build failed!');
+  expect(logs.find((log) => log.includes('TS6202'))).toBeTruthy();
+
+  restore();
+});

--- a/test/e2e/with-rsbuild/tsconfig.circular.json
+++ b/test/e2e/with-rsbuild/tsconfig.circular.json
@@ -1,0 +1,11 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./__fixtures__/solution-builder/a"
+    },
+    {
+      "path": "./__fixtures__/solution-builder/b"
+    }
+  ]
+}


### PR DESCRIPTION
## What's changed

- Added a SolutionBuilder-host `reportDiagnostic` handler to capture and report host-level diagnostics immediately. When a `builderProgram` is later available, merges host-level diagnostics with program diagnostics for the root config, so users see a complete set of issues.
- Added an e2e test that creates a circular project references setup and asserts the build fails and logs include the expected diagnostic (e.g. TS6202).

## Why

SolutionBuilder can surface diagnostics while it is building/validating the project graph (e.g. invalid or cyclic project references).
Those diagnostics may appear before a program is created, so relying only on program-level reporting can miss or delay them.

## Related

https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/issues/804