### PR TITLE
README: No longer recommend TypeScript Build mode for incremental

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,8 @@ setting "generateTrace" compiler option. This is an instruction from [microsoft/
 ## Enabling incremental mode
 
 TypeScript's "incremental" mode speeds up initial cold-start typechecks keeping an on-disk cache.
-It does not speed up subsequent subsequent re-typechecking during the runtime of the Rspack dev-server.
+
+It does not speed up subsequent subsequent re-typechecking during the runtime of the dev server.
 
 To enable incremental mode, set `"compilerOptions.incremental": true` in your `tsconfig.json`:
 


### PR DESCRIPTION
In Rspack, when I do [enable incremental mode](https://github.com/rstackjs/ts-checker-rspack-plugin/blob/cd88aae8478df0ecaa7450e669b02f27fe8c32e5/README.md#enabling-incremental-mode), the added `typescript: { build: true, },` makes my build much slower:

Each save of `page.tsx` now takes

```
[type-check] no errors found in 13533 ms
```

instead of

```
[type-check] no errors found in 1629 ms
```

I got the below explanation from Google Gemini, and could validate it experimentally: By just enabling `incremental` I got the cold-start speedup, but not the hot-re-typecheck slowdown shown above.

Since that is an almost 10x difference, I'm suggesting this PR to update the docs accordingly.

I still have some minor uncertainty:

* Is it really expected that build mode is this much slower?
  * `tsc --build` also has a `--watch` flag, I wonder what "mode" that really produces.
* In the PR that originally added this (https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/pull/732), `write-references` was used. Only later was that changed to `build: true`. I am not sure if that brought in a difference also.

Environment:

* `worker-rspack-loader` 3.1.2
* `typescript` 5.6.2


# Gemini-generated explanation

The reason your build became slower is that enabling `typescript: { build: true }` switches the plugin to use TypeScript's **Solution Builder API** (equivalent to `tsc --build`), which is often heavier than the standard **Watch API** used by default.

### The Fix
**Remove** the `build: true` option from your `TsCheckerRspackPlugin` configuration.

```diff
new TsCheckerRspackPlugin({
  typescript: {
-   build: true,
    // You can keep 'incremental: true' in your tsconfig.json
    // but don't enable 'build' mode in the plugin unless necessary.
  },
})
```

### Why was it slower?

1.  **Watch API vs. Solution Builder:**
    *   **Default (`build: false`):** The plugin uses the standard TypeScript **Watch API**. This keeps your project's program state in memory. When you save a file, it only re-checks the specific graph of files affected by that change. It is highly optimized for "hot" reloading.
    *   **Solution Builder (`build: true`):** This uses the API behind `tsc --build`. It is designed to orchestrate complex "Composite Projects" (monorepos with Project References). On every change, it has to check the "up-to-date" status of projects on disk, which adds overhead. For a single project, this is often slower than the in-memory Watch API.

2.  **"Incremental" Misconception:**
    You likely saw instructions to enable `incremental: true` in `tsconfig.json` to speed up builds. This is good advice, but it works differently depending on the mode:
    *   **With standard watch (Recommended):** `incremental: true` helps the *initial* cold start be faster by reading from the `.tsbuildinfo` file. Subsequent re-checks are fast because they are in-memory.
    *   **With `build: true`:** It forces the plugin to strictly follow the "build mode" logic, which might be re-validating more than necessary for a simple file save.

**Summary:** Keep `incremental: true` in your `tsconfig.json` for faster startup, but let the plugin run in its default mode (without `build: true`) to get the fastest re-check times during development.