### PR TITLE
fix: update peer dependency for @rspack/core v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "picocolors": "^1.1.1"
   },
   "peerDependencies": {
-    "@rspack/core": "^1.0.0",
+    "@rspack/core": "^1.0.0 || ^2.0.0-0",
     "typescript": ">=3.8.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Expanded the `@rspack/core` peer dependency version range in `package.json` from `^1.0.0` to `^1.0.0 || ^2.0.0-0`, enabling support for upcoming v2 prereleases.