### PR TITLE
chore: upgrade pnpm to 11.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
       "optional": true
     }
   },
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@11.1.2",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages:
   - 'examples/*'
   - 'test/**/*'
+
+allowBuilds:
+  core-js: false


### PR DESCRIPTION
## Summary

This PR upgrades the repository package manager metadata to pnpm 11.1.2 and updates pnpm 11 install configuration where dependency build scripts need an explicit allowBuilds decision. Lockfile or small validation fixes are included only where pnpm 11/local checks required them.

## Related Links

- https://github.com/pnpm/pnpm/releases/tag/v11.1.2
- https://github.com/pnpm/pnpm/releases/tag/v11.0.0
