### PR TITLE
chore: build before stage publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,5 +33,8 @@ jobs:
       - name: Install Dependencies
         run: pnpm i
 
+      - name: Build Packages
+        run: pnpm build
+
       - name: Publish
         run: pnpm stage publish --no-git-checks

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint": "rslint",
     "lint:write": "rslint --fix",
     "precommit": "pnpm build && pnpm test:unit",
-    "prepare": "husky && pnpm build",
+    "prepare": "husky",
     "test": "pnpm build && pnpm test:unit && pnpm test:e2e",
     "test:e2e": "cd test/e2e && pnpm test",
     "test:e2e:setup": "cd test/e2e && pnpm run setup",


### PR DESCRIPTION
## Summary

- Build packages in the release workflow before `pnpm stage publish`.
- Remove duplicate build commands from `scripts.prepare` where present.

## Validation

- Verified staged publish workflows have a preceding `pnpm build`.
- Ran `git diff --check`.