### PR TITLE
chore: Add homepage package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "type": "git",
     "url": "https://github.com/rstackjs/ts-checker-rspack-plugin.git"
   },
+  "homepage": "https://github.com/rstackjs/ts-checker-rspack-plugin#readme",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
## Summary
- adds missing npm support/discovery metadata for `ts-checker-rspack-plugin`
- updates only `package.json`

## Metadata added
- `homepage`: `https://github.com/rstackjs/ts-checker-rspack-plugin#readme`

## Validation
- parsed `package.json` as JSON after the change
- confirmed the changed manifest still has `name: ts-checker-rspack-plugin`
- checked this is metadata-only: no runtime code, dependencies, exports, generated assets, or build behavior changed

This small metadata fix makes the published npm package point users to the project README and/or public issue tracker once the package is next released.