### PR TITLE
chore: add lint check to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,9 @@ jobs:
       with:
         run_install: true
 
+    - name: Run lint
+      run: pnpm lint
+
     - name: Build project
       run: pnpm build
 

--- a/src/typescript/type-script-go-runner.ts
+++ b/src/typescript/type-script-go-runner.ts
@@ -59,6 +59,7 @@ function logOutput(logger: Pick<Logger, 'error'>, output: string) {
 }
 
 function stripAnsi(output: string) {
+  // rslint-disable-next-line no-control-regex
   return output.replace(/\u001b\[[0-?]*[ -/]*[@-~]/g, '');
 }
 


### PR DESCRIPTION
## Summary

- Add the lint command to the main CI workflow so lint regressions are caught before the build step.
- Suppress rslint's `no-control-regex` rule for the ANSI escape stripping regex, which intentionally matches control sequences.