### PR TITLE
feat: update TypeScript latest install guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,17 +128,17 @@ In this mode, the plugin runs the TypeScript Go binary in a child process, parse
 
 Supported options include `typescript.configFile`, `typescript.context`, `typescript.build`, `typescript.resolveRoot`, `typescript.typescriptPath`, `async`, and `logger`. It also supports `tsconfig.json` compiler options used by `tsgo`, including `incremental` and `composite`.
 
-Install TypeScript 7.0 RC to enable `tsgo` automatically:
+Install the latest TypeScript to enable `tsgo` automatically:
 
 ```sh
 # with npm
-npm install -D typescript@rc
+npm install -D typescript@latest
 
 # with yarn
-yarn add -D typescript@rc
+yarn add -D typescript@latest
 
 # with pnpm
-pnpm add -D typescript@rc
+pnpm add -D typescript@latest
 ```
 
 Or install `@typescript/native-preview` and enable `tsgo` explicitly:
@@ -162,7 +162,7 @@ new TsCheckerRspackPlugin({
 });
 ```
 
-> The `@typescript/native-preview` usage is deprecated and kept only for compatibility. We recommend installing `typescript@rc` to use `tsgo`.
+> The `@typescript/native-preview` usage is deprecated and kept only for compatibility. We recommend installing `typescript@latest` to use `tsgo`.
 
 Limitations:
 

--- a/src/typescript/type-script-go-runner.ts
+++ b/src/typescript/type-script-go-runner.ts
@@ -32,7 +32,7 @@ function resolveTypeScriptGoPackageJsonPath(config: TypeScriptWorkerConfig): str
 
   if (!config.tsgoPackage) {
     throw new Error(
-      `The typescriptPath option must point to "${TYPESCRIPT_PREVIEW_PACKAGE_JSON}" or "${TYPESCRIPT_PACKAGE}@rc".`,
+      `The typescriptPath option must point to "${TYPESCRIPT_PREVIEW_PACKAGE_JSON}" or "${TYPESCRIPT_PACKAGE}@latest".`,
     );
   }
 

--- a/src/typescript/type-script-support.ts
+++ b/src/typescript/type-script-support.ts
@@ -47,12 +47,12 @@ function isDefaultTypeScriptGoPath(typescriptPath: string): boolean {
 
 function createTypeScriptGoSupportError(config: TypeScriptWorkerConfig, error?: unknown) {
   const message = [
-    `When you enable TsCheckerRspackPlugin with \`typescript.tsgo\`, you must install \`${TYPESCRIPT_PACKAGE}@rc\` or \`${TYPESCRIPT_PREVIEW_PACKAGE}\` package.`,
+    `When you enable TsCheckerRspackPlugin with \`typescript.tsgo\`, you must install \`${TYPESCRIPT_PACKAGE}@latest\` or \`${TYPESCRIPT_PREVIEW_PACKAGE}\` package.`,
   ];
 
   if (!isDefaultTypeScriptGoPath(config.typescriptPath)) {
     message.push(
-      `If you set \`typescript.typescriptPath\`, it must be an absolute path to \`${TYPESCRIPT_PACKAGE_JSON}\` from \`${TYPESCRIPT_PACKAGE}@rc\` or \`${TYPESCRIPT_PREVIEW_PACKAGE_JSON}\`.`,
+      `If you set \`typescript.typescriptPath\`, it must be an absolute path to \`${TYPESCRIPT_PACKAGE_JSON}\` from \`${TYPESCRIPT_PACKAGE}@latest\` or \`${TYPESCRIPT_PREVIEW_PACKAGE_JSON}\`.`,
     );
   }
 
@@ -61,7 +61,7 @@ function createTypeScriptGoSupportError(config: TypeScriptWorkerConfig, error?: 
   }
 
   message.push(
-    `You can install it with \`npm add ${TYPESCRIPT_PACKAGE}@rc -D\` or \`npm add ${TYPESCRIPT_PREVIEW_PACKAGE} -D\`.`,
+    `You can install it with \`npm add ${TYPESCRIPT_PACKAGE}@latest -D\` or \`npm add ${TYPESCRIPT_PREVIEW_PACKAGE} -D\`.`,
   );
 
   return new Error(message.join(os.EOL));

--- a/test/unit/typescript/type-script-go-runner.spec.ts
+++ b/test/unit/typescript/type-script-go-runner.spec.ts
@@ -158,7 +158,7 @@ describe('typescript/type-script-go-runner', () => {
         typescriptPath: packageJsonPath,
         tsgoPackage: undefined,
       }),
-    ).toThrowError('typescript@rc');
+    ).toThrowError('typescript@latest');
   });
 
   it('extracts the error count from tsgo summary output', async () => {

--- a/test/unit/typescript/type-script-support.spec.ts
+++ b/test/unit/typescript/type-script-support.spec.ts
@@ -120,7 +120,7 @@ describe('typescript/type-script-support', () => {
     }
 
     expect(error?.message).toContain(
-      'When you enable TsCheckerRspackPlugin with `typescript.tsgo`, you must install `typescript@rc` or `@typescript/native-preview` package.'
+      'When you enable TsCheckerRspackPlugin with `typescript.tsgo`, you must install `typescript@latest` or `@typescript/native-preview` package.'
     );
     expect(error?.message).toContain('If you set `typescript.typescriptPath`');
   });
@@ -179,7 +179,7 @@ describe('typescript/type-script-support', () => {
     }
 
     expect(error?.message).toContain(
-      'When you enable TsCheckerRspackPlugin with `typescript.tsgo`, you must install `typescript@rc` or `@typescript/native-preview` package.'
+      'When you enable TsCheckerRspackPlugin with `typescript.tsgo`, you must install `typescript@latest` or `@typescript/native-preview` package.'
     );
     expect(error?.message).not.toContain('If you set `typescript.typescriptPath`');
   });
@@ -202,7 +202,7 @@ describe('typescript/type-script-support', () => {
     }
 
     expect(error?.message).toContain(
-      'When you enable TsCheckerRspackPlugin with `typescript.tsgo`, you must install `typescript@rc` or `@typescript/native-preview` package.'
+      'When you enable TsCheckerRspackPlugin with `typescript.tsgo`, you must install `typescript@latest` or `@typescript/native-preview` package.'
     );
     expect(error?.message).not.toContain('If you set `typescript.typescriptPath`');
   });


### PR DESCRIPTION
## Summary

TypeScript 7.0 is now available through the standard `typescript` package, so the tsgo docs and runtime guidance should no longer direct users to the RC tag.

This PR updates the README installation examples, support errors, and unit test expectations from `typescript@rc` to `typescript@latest`, while keeping `@typescript/native-preview` documented as a deprecated compatibility path.

## Related Links

- https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/