### PR TITLE
fix: refine tsgo support errors

### DIFF
--- a/src/typescript/type-script-go-runner.ts
+++ b/src/typescript/type-script-go-runner.ts
@@ -32,7 +32,7 @@ function resolveTypeScriptGoPackageJsonPath(config: TypeScriptWorkerConfig): str
 
   if (!config.tsgoPackage) {
     throw new Error(
-      `The typescriptPath option must point to "${TYPESCRIPT_PREVIEW_PACKAGE_JSON}" or "${TYPESCRIPT_PACKAGE}@latest".`,
+      `The typescriptPath option must point to "${TYPESCRIPT_PREVIEW_PACKAGE_JSON}" or "${TYPESCRIPT_PACKAGE}@>=7".`,
     );
   }
 
@@ -50,7 +50,7 @@ async function resolveTypeScriptGoNativeExecutablePath(
 
   if (typeof getExePath !== 'function') {
     throw new Error(
-      `Cannot resolve the typescript-go executable from "${packageName}".`,
+      `Cannot resolve the native TypeScript executable from "${packageName}".`,
     );
   }
 

--- a/src/typescript/type-script-support.ts
+++ b/src/typescript/type-script-support.ts
@@ -47,22 +47,18 @@ function isDefaultTypeScriptGoPath(typescriptPath: string): boolean {
 
 function createTypeScriptGoSupportError(config: TypeScriptWorkerConfig, error?: unknown) {
   const message = [
-    `When you enable TsCheckerRspackPlugin with \`typescript.tsgo\`, you must install \`${TYPESCRIPT_PACKAGE}@latest\` or \`${TYPESCRIPT_PREVIEW_PACKAGE}\` package.`,
+    `\`typescript.tsgo\` requires \`${TYPESCRIPT_PACKAGE}\` >= 7.0.0 or legacy \`${TYPESCRIPT_PREVIEW_PACKAGE}\`.`,
   ];
 
   if (!isDefaultTypeScriptGoPath(config.typescriptPath)) {
     message.push(
-      `If you set \`typescript.typescriptPath\`, it must be an absolute path to \`${TYPESCRIPT_PACKAGE_JSON}\` from \`${TYPESCRIPT_PACKAGE}@latest\` or \`${TYPESCRIPT_PREVIEW_PACKAGE_JSON}\`.`,
+      `\`typescript.typescriptPath\` must be an absolute path to \`${TYPESCRIPT_PACKAGE_JSON}\` or \`${TYPESCRIPT_PREVIEW_PACKAGE_JSON}\`.`,
     );
   }
 
   if (error instanceof Error && error.message) {
-    message.push(`Failed to resolve the tsgo executable: ${error.message}`);
+    message.push(`Failed to resolve the native TypeScript executable: ${error.message}`);
   }
-
-  message.push(
-    `You can install it with \`npm add ${TYPESCRIPT_PACKAGE}@latest -D\` or \`npm add ${TYPESCRIPT_PREVIEW_PACKAGE} -D\`.`,
-  );
 
   return new Error(message.join(os.EOL));
 }

--- a/test/unit/typescript/type-script-go-runner.spec.ts
+++ b/test/unit/typescript/type-script-go-runner.spec.ts
@@ -158,7 +158,7 @@ describe('typescript/type-script-go-runner', () => {
         typescriptPath: packageJsonPath,
         tsgoPackage: undefined,
       }),
-    ).toThrowError('typescript@latest');
+    ).toThrowError('typescript@>=7');
   });
 
   it('extracts the error count from tsgo summary output', async () => {

--- a/test/unit/typescript/type-script-support.spec.ts
+++ b/test/unit/typescript/type-script-support.spec.ts
@@ -6,6 +6,10 @@ import type { TypeScriptWorkerConfig } from 'src/typescript/type-script-worker-c
 describe('typescript/type-script-support', () => {
   let configuration: TypeScriptWorkerConfig;
   const tempDirs: string[] = [];
+  const tsgoRequirementMessage =
+    '`typescript.tsgo` requires `typescript` >= 7.0.0 or legacy `@typescript/native-preview`.';
+  const tsgoPathMessage =
+    '`typescript.typescriptPath` must be an absolute path to `typescript/package.json` or `@typescript/native-preview/package.json`.';
 
   function createTypeScriptPackage(version: string) {
     const packagePath = fs.mkdtempSync(path.join(os.tmpdir(), 'ts-checker-typescript-support-'));
@@ -119,10 +123,8 @@ describe('typescript/type-script-support', () => {
       error = caughtError as Error;
     }
 
-    expect(error?.message).toContain(
-      'When you enable TsCheckerRspackPlugin with `typescript.tsgo`, you must install `typescript@latest` or `@typescript/native-preview` package.'
-    );
-    expect(error?.message).toContain('If you set `typescript.typescriptPath`');
+    expect(error?.message).toContain(tsgoRequirementMessage);
+    expect(error?.message).toContain(tsgoPathMessage);
   });
 
   it('supports TypeScript package with native executable for tsgo', async () => {
@@ -178,10 +180,8 @@ describe('typescript/type-script-support', () => {
       existsSyncSpy.mockRestore();
     }
 
-    expect(error?.message).toContain(
-      'When you enable TsCheckerRspackPlugin with `typescript.tsgo`, you must install `typescript@latest` or `@typescript/native-preview` package.'
-    );
-    expect(error?.message).not.toContain('If you set `typescript.typescriptPath`');
+    expect(error?.message).toContain(tsgoRequirementMessage);
+    expect(error?.message).not.toContain(tsgoPathMessage);
   });
 
   it('does not print the custom typescriptPath hint for the unresolved default tsgo path', async () => {
@@ -201,13 +201,13 @@ describe('typescript/type-script-support', () => {
       error = caughtError as Error;
     }
 
+    expect(error?.message).toContain(tsgoRequirementMessage);
     expect(error?.message).toContain(
-      'When you enable TsCheckerRspackPlugin with `typescript.tsgo`, you must install `typescript@latest` or `@typescript/native-preview` package.'
+      'Failed to resolve the native TypeScript executable: The typescriptPath option must be an absolute path to a package.json file when tsgo is enabled.',
     );
-    expect(error?.message).not.toContain('If you set `typescript.typescriptPath`');
   });
 
-  it('throws error if the typescript-go executable cannot be resolved', async () => {
+  it('throws error if the native TypeScript executable cannot be resolved', async () => {
     const originalExistsSync = fs.existsSync;
     const existsSyncSpy = rs.spyOn(fs, 'existsSync').mockImplementation((filePath) => {
       const normalizedPath = filePath.toString().replace(/\\/g, '/');
@@ -221,14 +221,23 @@ describe('typescript/type-script-support', () => {
     const { assertTypeScriptGoExecutable } = await import('src/typescript/type-script-support');
 
     try {
-      await expect(
-        assertTypeScriptGoExecutable({
+      let error: Error | undefined;
+
+      try {
+        await assertTypeScriptGoExecutable({
           ...configuration,
           typescriptPath: require.resolve('@typescript/native-preview/package.json'),
           tsgo: true,
           tsgoPackage: 'preview',
-        })
-      ).rejects.toThrowError('Failed to resolve the tsgo executable: Executable not found');
+        });
+      } catch (caughtError) {
+        error = caughtError as Error;
+      }
+
+      expect(error?.message).toContain(tsgoRequirementMessage);
+      expect(error?.message).toContain(
+        'Failed to resolve the native TypeScript executable: Executable not found',
+      );
     } finally {
       existsSyncSpy.mockRestore();
     }


### PR DESCRIPTION
This PR makes the `typescript.tsgo` support errors shorter and clearer now that TypeScript 7 is the stable package path.

It removes package-manager-specific install commands from the runtime error, uses an explicit `typescript >= 7.0.0` requirement, and keeps the tests aligned with the new messages.