### PR TITLE
chore: update pnpm release age exclusions

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,8 +6,14 @@ allowBuilds:
   core-js: false
 
 minimumReleaseAgeExclude:
+  - '@rsbuild/*'
+  - '@rslib/*'
+  - '@rslint/*'
+  - '@rspack/*'
+  - '@rspress/*'
+  - '@rstackjs/*'
+  - '@rstest/*'
+  - '@typescript/*'
+  - 'rsbuild-plugin-*'
   - rstack
   - typescript
-  - '@typescript/*'
-  - '@rstest/*'
-  - '@rstackjs/*'


### PR DESCRIPTION
## Summary

This PR updates `minimumReleaseAgeExclude` to exempt Rstack ecosystem packages from pnpm's minimum release age policy. It preserves existing exclusions and sorts the complete list alphabetically.