### PR TITLE
fix: support rspack dev server error overlay

### DIFF
--- a/src/hooks/intercept-done-to-get-dev-server-tap.ts
+++ b/src/hooks/intercept-done-to-get-dev-server-tap.ts
@@ -7,14 +7,18 @@ import type { TsCheckerRspackPluginState } from '../plugin-state';
 function interceptDoneToGetDevServerTap(
   compiler: rspack.Compiler,
   config: TsCheckerRspackPluginConfig,
-  state: TsCheckerRspackPluginState
+  state: TsCheckerRspackPluginState,
 ) {
   const { debug } = getInfrastructureLogger(compiler);
 
   // inspired by https://github.com/ypresto/fork-ts-checker-async-overlay-webpack-plugin
   compiler.hooks.done.intercept({
     register: (tap) => {
-      if (['webpack-dev-server', 'rsbuild-dev-server'].includes(tap.name) && tap.type === 'sync' && config.devServer) {
+      if (
+        ['webpack-dev-server', 'rsbuild-dev-server', 'rspack-dev-server'].includes(tap.name) &&
+        tap.type === 'sync' &&
+        config.devServer
+      ) {
         debug('Intercepting dev-server tap.');
         state.DevServerDoneTap = tap;
       }

--- a/test/unit/hooks/intercept-done-to-get-dev-server-tap.spec.ts
+++ b/test/unit/hooks/intercept-done-to-get-dev-server-tap.spec.ts
@@ -1,0 +1,24 @@
+import { rspack } from '@rspack/core';
+
+import { interceptDoneToGetDevServerTap } from 'src/hooks/intercept-done-to-get-dev-server-tap';
+import type { TsCheckerRspackPluginConfig } from 'src/plugin-config';
+import { createPluginState } from 'src/plugin-state';
+
+describe('interceptDoneToGetDevServerTap', () => {
+  it('captures the rspack-dev-server done tap', () => {
+    const compiler = rspack({});
+    const state = createPluginState();
+
+    interceptDoneToGetDevServerTap(
+      compiler,
+      { devServer: true } as TsCheckerRspackPluginConfig,
+      state,
+    );
+
+    const done = () => {};
+    compiler.hooks.done.tap('rspack-dev-server', done);
+
+    expect(state.DevServerDoneTap?.name).toBe('rspack-dev-server');
+    expect(state.DevServerDoneTap?.fn).toBe(done);
+  });
+});


### PR DESCRIPTION
## Summary

- recognize the `rspack-dev-server` done hook when dev-server integration is enabled
- add a regression test that verifies the hook is captured

## Root cause

The plugin only recognized the `webpack-dev-server` and `rsbuild-dev-server` tap names. As a result, diagnostics were not forwarded through rspack-dev-server's done tap and its browser error overlay was not triggered.

## Impact

Type-checking compilation errors can now reach the browser error overlay when running an application with `rspack serve`.

## Tests

- `pnpm build`
- `pnpm test:unit`
- `pnpm lint`
- `pnpm exec prettier --check src/hooks/intercept-done-to-get-dev-server-tap.ts test/unit/hooks/intercept-done-to-get-dev-server-tap.spec.ts`

Closes #125