### PR TITLE
fix: support ts7 project reference builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ Supported options include:
 - [`typescript.configFile`](#configfile)
 - [`typescript.context`](#context)
 - [`typescript.build`](#build)
-- `typescript.resolveRoot`
-- `typescript.typescriptPath`
+- [`typescript.mode`](#mode)
+- [`typescript.resolveRoot`](#resolveroot)
+- [`typescript.typescriptPath`](#typescriptpath)
 - [`async`](#async)
 - [`logger`](#logger)
 
@@ -127,7 +128,9 @@ Limitations:
 - [`issue.include`](#include), [`issue.exclude`](#exclude), and [`issue.defaultSeverity`](#defaultseverity) only apply to diagnostics whose checker output can be matched by `file`, `line`, `column`, `code`, and `message`.
 - [`typescript.configOverwrite`](#configoverwrite), [`typescript.diagnosticOptions`](#diagnosticoptions), and [`typescript.profile`](#profile) are not supported.
 - TypeScript API-based formatting or filesystem output rewrites are not supported.
-- Plugin-controlled declaration or reference emit modes such as `write-dts` and `write-references` are not supported. `tsgo` always runs with `--noEmit`.
+- `write-dts` mode is not supported.
+- In build mode, `readonly` and `write-tsbuildinfo` cannot rebuild projects with references because the native TypeScript CLI cannot emit their required outputs with `--noEmit`. Use `write-references`, or build them separately and disable `typescript.build` for the checker.
+- `write-references` writes and reuses normal build outputs, including `.tsbuildinfo`; the plugin does not clean them.
 - This integration may change when TypeScript provides a stable JavaScript API for the native checker.
 
 ## Options

--- a/src/typescript/type-script-go-runner.ts
+++ b/src/typescript/type-script-go-runner.ts
@@ -87,9 +87,15 @@ async function resolveTypeScriptGoExecutable(
 function createTypeScriptGoArgs(config: TypeScriptWorkerConfig) {
   const args = config.build ? ['--build', config.configFile] : ['--project', config.configFile];
 
-  // Keep tsgo as a checker in this plugin. Incremental .tsbuildinfo is still controlled
-  // by tsconfig's `incremental` / `composite` options, matching the compiler CLI.
-  args.push('--noEmit', '--pretty');
+  if (config.build && config.mode === 'write-references') {
+    args.push('--noEmit', 'false');
+  } else {
+    // Incremental .tsbuildinfo is still controlled by tsconfig's `incremental` /
+    // `composite` options, matching the compiler CLI.
+    args.push('--noEmit');
+  }
+
+  args.push('--pretty');
 
   return args;
 }
@@ -132,6 +138,26 @@ function createTypeScriptGoIssue(message: string): Issue {
     code: TYPESCRIPT_GO_ISSUE_CODE,
     message,
   };
+}
+
+function getTypeScriptGoDiagnosticMessage(
+  code: string,
+  message: string,
+  config: TypeScriptWorkerConfig,
+) {
+  if (
+    code === '6310' &&
+    config.build &&
+    (config.mode === 'readonly' || config.mode === 'write-tsbuildinfo')
+  ) {
+    return [
+      message,
+      'The native TypeScript checker cannot rebuild projects with references without emitting their required outputs.',
+      'Set `typescript.mode` to `write-references`, or build the references separately and set `typescript.build` to false.',
+    ].join(' ');
+  }
+
+  return message;
 }
 
 const diagnosticPattern = /^(.*?):(\d+):(\d+)\s+-\s+(error|warning)\s+TS(\d+):\s+(.+)$/;
@@ -183,7 +209,7 @@ function parseTypeScriptGoIssues(
     issues.push({
       severity: getTypeScriptGoIssueSeverity(severity as Issue['severity'], defaultSeverity),
       code: `TS${code}`,
-      message,
+      message: getTypeScriptGoDiagnosticMessage(code, message, config),
       file: path.isAbsolute(file) ? file : path.resolve(config.context, file),
       location: {
         start: position,
@@ -201,7 +227,7 @@ function parseTypeScriptGoIssues(
     issues.push({
       severity: getTypeScriptGoIssueSeverity(severity as Issue['severity'], defaultSeverity),
       code: `TS${code}`,
-      message,
+      message: getTypeScriptGoDiagnosticMessage(code, message, config),
     });
   }
 

--- a/test/e2e/with-rsbuild/__fixtures__/tsgo-references/app/index.ts
+++ b/test/e2e/with-rsbuild/__fixtures__/tsgo-references/app/index.ts
@@ -1,0 +1,1 @@
+export const appValue = 7;

--- a/test/e2e/with-rsbuild/__fixtures__/tsgo-references/src/index.ts
+++ b/test/e2e/with-rsbuild/__fixtures__/tsgo-references/src/index.ts
@@ -1,0 +1,1 @@
+export const referencedValue = 42;

--- a/test/e2e/with-rsbuild/__fixtures__/tsgo-references/tsconfig.json
+++ b/test/e2e/with-rsbuild/__fixtures__/tsgo-references/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "module": "ES2020",
+    "noEmit": true,
+    "outDir": "./dist/reference",
+    "rootDir": "./src",
+    "target": "ES2021",
+    "tsBuildInfoFile": "./dist/reference/tsconfig.tsbuildinfo"
+  },
+  "include": ["src"]
+}

--- a/test/e2e/with-rsbuild/index.test.ts
+++ b/test/e2e/with-rsbuild/index.test.ts
@@ -265,6 +265,40 @@ test('should respect issue exclude for typescript-go diagnostics', async () => {
   expect(logs.find((log) => log.includes('TS2345'))).toBeFalsy();
 });
 
+test('should build unbuilt project references with typescript-go in write-references mode', async () => {
+  const outputDir = resolve(__dirname, '__fixtures__/tsgo-references/dist');
+
+  await rm(outputDir, { recursive: true, force: true });
+
+  try {
+    const rsbuild = await createRsbuild({
+      rsbuildConfig: {
+        tools: {
+          rspack: {
+            plugins: [
+              new TsCheckerRspackPlugin({
+                typescript: {
+                  build: true,
+                  configFile: './tsconfig.tsgo.references.json',
+                  mode: 'write-references',
+                  tsgo: true,
+                },
+              }),
+            ],
+          },
+        },
+      },
+    });
+
+    await expect(rsbuild.build()).resolves.toBeTruthy();
+    await expect(stat(resolve(outputDir, 'app/index.js'))).resolves.toBeTruthy();
+    await expect(stat(resolve(outputDir, 'reference/index.js'))).resolves.toBeTruthy();
+    await expect(stat(resolve(outputDir, 'reference/index.d.ts'))).resolves.toBeTruthy();
+  } finally {
+    await rm(outputDir, { recursive: true, force: true });
+  }
+});
+
 test('should rerun typescript-go on rebuild and update incremental build info', async () => {
   const { logs, restore } = proxyConsole();
 

--- a/test/e2e/with-rsbuild/tsconfig.tsgo.references.json
+++ b/test/e2e/with-rsbuild/tsconfig.tsgo.references.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "ES2020",
+    "noEmit": true,
+    "outDir": "./__fixtures__/tsgo-references/dist/app",
+    "rootDir": "./__fixtures__/tsgo-references/app",
+    "target": "ES2021",
+    "tsBuildInfoFile": "./__fixtures__/tsgo-references/dist/app/tsconfig.tsbuildinfo"
+  },
+  "include": ["./__fixtures__/tsgo-references/app"],
+  "references": [
+    {
+      "path": "./__fixtures__/tsgo-references"
+    }
+  ]
+}

--- a/test/unit/typescript/type-script-go-runner.spec.ts
+++ b/test/unit/typescript/type-script-go-runner.spec.ts
@@ -87,6 +87,25 @@ describe('typescript/type-script-go-runner', () => {
     ]);
   });
 
+  it('creates tsgo emit args for project references in write-references mode', async () => {
+    const { createTypeScriptGoArgs } = await import('src/typescript/type-script-go-runner');
+
+    expect(
+      createTypeScriptGoArgs({ ...config, build: true, mode: 'write-references' }),
+    ).toEqual(['--build', config.configFile, '--noEmit', 'false', '--pretty']);
+  });
+
+  it('keeps write-references read-only outside build mode', async () => {
+    const { createTypeScriptGoArgs } = await import('src/typescript/type-script-go-runner');
+
+    expect(createTypeScriptGoArgs({ ...config, mode: 'write-references' })).toEqual([
+      '--project',
+      config.configFile,
+      '--noEmit',
+      '--pretty',
+    ]);
+  });
+
   it('creates coarse watcher dependencies without parsing tsconfig', async () => {
     const { getTypeScriptGoDependencies } = await import('src/typescript/type-script-go-runner');
 
@@ -246,6 +265,24 @@ describe('typescript/type-script-go-runner', () => {
         code: 'TS2345',
         message: 'Type mismatch.',
         severity: 'warning',
+      },
+    ]);
+  });
+
+  it('explains how to check project references when tsgo cannot disable emit', async () => {
+    const { parseTypeScriptGoIssues } = await import('src/typescript/type-script-go-runner');
+
+    expect(
+      parseTypeScriptGoIssues(
+        "tsconfig.json:1:1 - error TS6310: Referenced project './packages/shared' may not disable emit.",
+        { ...config, build: true, mode: 'write-tsbuildinfo' },
+      ),
+    ).toMatchObject([
+      {
+        code: 'TS6310',
+        message: expect.stringContaining(
+          'Set `typescript.mode` to `write-references`',
+        ),
       },
     ]);
   });


### PR DESCRIPTION
TypeScript 7's native checker always received `--noEmit`, so build mode could not rebuild unbuilt project references and `write-references` was ineffective.

This change lets `write-references` explicitly enable native build output while keeping read-only modes unchanged, and adds actionable TS6310 guidance. Unit and Rspack/Webpack end-to-end coverage verify clean project-reference builds.

Closes #127.