### PR TITLE
fix(ts7): Terminate canceled tsgo checks

### DIFF
--- a/src/typescript/type-script-go-runner.ts
+++ b/src/typescript/type-script-go-runner.ts
@@ -291,7 +291,7 @@ async function runTypeScriptGo(
     };
 
     const abort = () => {
-      childProcess.kill('SIGTERM');
+      childProcess.kill('SIGKILL');
       finish(() => reject(new AbortError()));
     };
 


### PR DESCRIPTION
While using the plugin with TypeScript 7 in watch mode, we saw canceled native `tsc` processes continue running and pile up across rebuilds. This reproduces when watched files are edited again before the previous type check finishes, since each rebuild cancels the current checker and starts another one.

We reproduced this in [Sentry's Rspack development setup](https://github.com/getsentry/sentry/blob/07a692838acc8519719dafc0a0242b6fa9517cfc/rspack.config.ts#L433-L442).

`SIGTERM` did not stop the native checker in our reproduction, while `SIGKILL` terminated it immediately. Since these checks run with `--noEmit`, force-killing canceled checks should keep old processes from accumulating while new checks start.