### PR TITLE
fix: detect root file changes before invalidation

### DIFF
--- a/src/typescript/worker/get-issues-worker.ts
+++ b/src/typescript/worker/get-issues-worker.ts
@@ -48,11 +48,13 @@ const getIssuesWorker = async (
 
     invalidateTsBuildInfo();
   } else if (didDependenciesProbablyChanged(getDependencies(), change)) {
+    const rootFilesChanged = didRootFilesChanged();
+
     invalidateConfig();
     invalidateDependencies();
     invalidateArtifacts();
 
-    if (didRootFilesChanged()) {
+    if (rootFilesChanged) {
       invalidateWatchProgramRootFileNames();
       invalidateSolutionBuilder();
     }

--- a/test/e2e/with-rsbuild/index.test.ts
+++ b/test/e2e/with-rsbuild/index.test.ts
@@ -90,6 +90,57 @@ test('should throw error when exist type errors in dev mode', async ({ page }) =
   await server.close();
 });
 
+test('should type-check a root file added in dev mode', { timeout: 30_000 }, async ({ page }) => {
+  const { logs, restore } = proxyConsole();
+  const rootFilePath = resolve(__dirname, 'src/root-file-watch.ts');
+
+  await rm(rootFilePath, { force: true });
+
+  const rsbuild = await createRsbuild({
+    rsbuildConfig: {
+      tools: {
+        rspack: {
+          plugins: [
+            new TsCheckerRspackPlugin({
+              async: false,
+            }),
+          ],
+        },
+      },
+    },
+  });
+
+  const { server, urls } = await rsbuild.startDevServer();
+
+  try {
+    await page.goto(urls[0]);
+
+    const initialLogCount = logs.length;
+    await writeFile(rootFilePath, "const rootFileValue: number = 'root file';\n");
+
+    await expect
+      .poll(
+        () => {
+          const rebuildLogs = logs.slice(initialLogCount);
+          return (
+            rebuildLogs.some(
+              (log) => log.includes('File:') && log.includes('root-file-watch.ts'),
+            ) &&
+            rebuildLogs.some((log) =>
+              log.includes(`Type 'string' is not assignable to type 'number'.`),
+            )
+          );
+        },
+        { timeout: 20_000 },
+      )
+      .toBeTruthy();
+  } finally {
+    restore();
+    await server.close();
+    await rm(rootFilePath, { force: true });
+  }
+});
+
 test('should not throw error when the file is excluded', async () => {
   const rsbuild = await createRsbuild({
     rsbuildConfig: {


### PR DESCRIPTION
## Summary

Fix watch-mode root-file detection by comparing the current and next parsed TypeScript configs before invalidating the cached config. Previously, invalidation discarded the previous root-file list, so newly added or restored root files were not recognized and the existing watch program was not told to refresh its roots.

Add a focused Rstest + Playwright regression that creates an unimported TypeScript root file during dev mode and verifies that its diagnostic is reported. This PR intentionally contains no watcher recreation, RPC, dependency, lockfile, CI, or other production changes.

## Validation

- `pnpm lint`
- `pnpm test` — 129 tests, 0 failures
- Confirmed the new regression fails against `main` and passes with this fix

## Related

- Split from #132