### PR TITLE
perf: reuse cached parent real paths

### DIFF
--- a/src/typescript/worker/lib/file-system/real-file-system.ts
+++ b/src/typescript/worker/lib/file-system/real-file-system.ts
@@ -120,8 +120,20 @@ function getRealPath(path: string) {
     let nested = '';
 
     while (base !== dirname(base)) {
+      const cachedBase = realPathCache.get(base);
+      if (cachedBase) {
+        realPathCache.set(normalizedPath, normalize(join(cachedBase, nested)));
+        break;
+      }
+
       if (exists(base)) {
-        realPathCache.set(normalizedPath, normalize(join(fs.realpathSync(base), nested)));
+        const realBase = normalize(fs.realpathSync(base));
+
+        // Cache the existing ancestor as well as the requested path. TypeScript
+        // probes many non-existent extensions below the same directory during
+        // module resolution, so resolving that directory repeatedly is costly.
+        realPathCache.set(base, realBase);
+        realPathCache.set(normalizedPath, normalize(join(realBase, nested)));
         break;
       }
 

--- a/test/unit/typescript/real-file-system.spec.ts
+++ b/test/unit/typescript/real-file-system.spec.ts
@@ -1,0 +1,54 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { realFileSystem } from 'src/typescript/worker/lib/file-system/real-file-system';
+
+describe('realFileSystem', () => {
+  let temporaryDirectory: string;
+
+  beforeEach(() => {
+    temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'ts-checker-real-fs-'));
+    realFileSystem.clearCache();
+  });
+
+  afterEach(() => {
+    realFileSystem.clearCache();
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+    rs.restoreAllMocks();
+  });
+
+  it('reuses a cached real path for non-existent siblings', () => {
+    const parentDirectory = path.join(temporaryDirectory, 'parent');
+    fs.mkdirSync(parentDirectory);
+    const realParentDirectory = fs.realpathSync(parentDirectory);
+    const realpathSpy = rs.spyOn(fs, 'realpathSync');
+
+    expect(realFileSystem.realPath(path.join(parentDirectory, 'first.ts'))).toBe(
+      path.join(realParentDirectory, 'first.ts'),
+    );
+    expect(realFileSystem.realPath(path.join(parentDirectory, 'second.ts'))).toBe(
+      path.join(realParentDirectory, 'second.ts'),
+    );
+
+    expect(realpathSpy).toHaveBeenCalledTimes(1);
+    expect(realpathSpy).toHaveBeenCalledWith(parentDirectory);
+  });
+
+  it('still resolves an existing symlink below a cached parent path', () => {
+    const parentDirectory = path.join(temporaryDirectory, 'parent');
+    const targetDirectory = path.join(temporaryDirectory, 'target');
+    const linkedDirectory = path.join(parentDirectory, 'linked');
+    fs.mkdirSync(parentDirectory);
+    fs.mkdirSync(targetDirectory);
+    fs.symlinkSync(
+      targetDirectory,
+      linkedDirectory,
+      process.platform === 'win32' ? 'junction' : 'dir',
+    );
+
+    realFileSystem.realPath(path.join(parentDirectory, 'missing.ts'));
+
+    expect(realFileSystem.realPath(linkedDirectory)).toBe(fs.realpathSync(targetDirectory));
+  });
+});


### PR DESCRIPTION
## Summary

TypeScript module resolution probes many non-existent file candidates under the same directories, causing repeated `fs.realpathSync` calls. This change caches resolved existing ancestors while still resolving existing child symlinks independently, with regression coverage for both behaviors.

## Performance

Measured against `2c9a279` on Node.js 24.12.0 using `react-1k`, `react-5k`, and `react-10k` from build-tools-performance. Each variant used an isolated persistent-cache version with 2 warmups and 7 interleaved measured runs.

| Case | Baseline median | Optimized median | Improvement |
| --- | ---: | ---: | ---: |
| react-1k | 1793.5 ms | 1631.0 ms | 9.1% |
| react-5k | 6243.5 ms | 4880.2 ms | 21.8% |
| react-10k | 11997.1 ms | 8789.4 ms | 26.7% |

In the `react-5k` issues-worker CPU profile, `realpathSync` total time decreased from about 1.21 s to 0.59 s (51.1%), while total sampled worker time decreased from 5.25 s to 4.73 s (9.9%). `pnpm lint` and the full `pnpm test` suite pass (160 tests).

## Related Links

- https://github.com/rstackjs/build-tools-performance