### PR TITLE
perf: bypass unused readonly file system overlay

### DIFF
--- a/src/typescript/worker/lib/file-system/mem-file-system.ts
+++ b/src/typescript/worker/lib/file-system/mem-file-system.ts
@@ -6,11 +6,26 @@ import { fs as mem } from 'memfs';
 import type { FileSystem } from './file-system';
 import { realFileSystem } from './real-file-system';
 
+interface MemFileSystem extends FileSystem {
+  /**
+   * Whether the in-memory layer may contain changes that should overlay files on disk.
+   */
+  hasChanges(): boolean;
+}
+
+// This flag is intentionally sticky: clearCache() only clears path caches and
+// does not remove files from memfs, so disk-only reads are no longer safe after
+// the first mutation.
+let hasChanges = false;
+
 /**
  * It's an implementation of FileSystem interface which reads and writes to the in-memory file system.
  */
-export const memFileSystem: FileSystem = {
+export const memFileSystem: MemFileSystem = {
   ...realFileSystem,
+  hasChanges() {
+    return hasChanges;
+  },
   exists(path: string) {
     return exists(realFileSystem.realPath(path));
   },
@@ -71,10 +86,12 @@ function readDir(path: string): Dirent[] {
 }
 
 function createDir(path: string) {
+  hasChanges = true;
   mem.mkdirSync(realFileSystem.normalizePath(path), { recursive: true });
 }
 
 function writeFile(path: string, data: string) {
+  hasChanges = true;
   if (!exists(dirname(path))) {
     createDir(dirname(path));
   }
@@ -83,12 +100,14 @@ function writeFile(path: string, data: string) {
 }
 
 function deleteFile(path: string) {
+  hasChanges = true;
   if (exists(path)) {
     mem.unlinkSync(realFileSystem.normalizePath(path));
   }
 }
 
 function updateTimes(path: string, atime: Date, mtime: Date) {
+  hasChanges = true;
   if (exists(path)) {
     mem.utimesSync(realFileSystem.normalizePath(path), atime, mtime);
   }

--- a/src/typescript/worker/lib/system.ts
+++ b/src/typescript/worker/lib/system.ts
@@ -308,7 +308,12 @@ function getReadFileSystem(path: string) {
     }
   }
 
-  return passiveFileSystem;
+  // Before readonly mode produces in-memory output, all non-artifact reads can
+  // go directly to disk. Once the memory layer changes (for example, when a
+  // SolutionBuilder emits a referenced project), preserve the overlay behavior.
+  return mode === 'readonly' && !memFileSystem.hasChanges()
+    ? realFileSystem
+    : passiveFileSystem;
 }
 
 function getWriteFileSystem(path: string) {

--- a/test/unit/typescript/system.spec.ts
+++ b/test/unit/typescript/system.spec.ts
@@ -1,0 +1,77 @@
+import type { Stats } from 'node:fs';
+
+import type { TypeScriptWorkerConfig } from 'src/typescript/type-script-worker-config';
+
+const originalWorkerData = process.env.WORKER_DATA;
+const fileStats = {
+  isFile: () => true,
+} as Stats;
+
+async function loadSystem(mode: TypeScriptWorkerConfig['mode']) {
+  process.env.WORKER_DATA = JSON.stringify({
+    mode,
+    typescriptPath: require.resolve('typescript'),
+  });
+  rs.resetModules();
+
+  const { memFileSystem } = await import(
+    'src/typescript/worker/lib/file-system/mem-file-system'
+  );
+  const { passiveFileSystem } = await import(
+    'src/typescript/worker/lib/file-system/passive-file-system'
+  );
+  const { realFileSystem } = await import(
+    'src/typescript/worker/lib/file-system/real-file-system'
+  );
+  const { system } = await import('src/typescript/worker/lib/system');
+
+  return { memFileSystem, passiveFileSystem, realFileSystem, system };
+}
+
+describe('typescript system', () => {
+  afterEach(() => {
+    if (originalWorkerData === undefined) {
+      delete process.env.WORKER_DATA;
+    } else {
+      process.env.WORKER_DATA = originalWorkerData;
+    }
+    rs.restoreAllMocks();
+    rs.resetModules();
+  });
+
+  it('reads non-artifact paths directly in readonly mode', async () => {
+    const { passiveFileSystem, realFileSystem, system } = await loadSystem('readonly');
+    const realReadStats = rs.spyOn(realFileSystem, 'readStats').mockReturnValue(fileStats);
+    const passiveReadStats = rs.spyOn(passiveFileSystem, 'readStats');
+
+    expect(system.fileExists('/project/source.ts')).toBe(true);
+    expect(realReadStats).toHaveBeenCalledWith('/project/source.ts');
+    expect(passiveReadStats).not.toHaveBeenCalled();
+  });
+
+  it('keeps using the passive file system in write modes', async () => {
+    const { passiveFileSystem, realFileSystem, system } =
+      await loadSystem('write-tsbuildinfo');
+    const realReadStats = rs.spyOn(realFileSystem, 'readStats');
+    const passiveReadStats = rs
+      .spyOn(passiveFileSystem, 'readStats')
+      .mockReturnValue(fileStats);
+
+    expect(system.fileExists('/project/source.ts')).toBe(true);
+    expect(passiveReadStats).toHaveBeenCalledWith('/project/source.ts');
+    expect(realReadStats).not.toHaveBeenCalled();
+  });
+
+  it('restores the passive overlay after readonly mode writes to memory', async () => {
+    const { memFileSystem, system } = await loadSystem('readonly');
+    const generatedPath = `/virtual/generated-${process.pid}.d.ts`;
+
+    expect(memFileSystem.hasChanges()).toBe(false);
+    memFileSystem.writeFile(generatedPath, 'export declare const value: number;\n');
+
+    expect(memFileSystem.hasChanges()).toBe(true);
+    expect(system.fileExists(generatedPath)).toBe(true);
+
+    memFileSystem.deleteFile(generatedPath);
+  });
+});


### PR DESCRIPTION
## Summary

Readonly checks previously routed every file read through the passive disk/memory overlay, even before the in-memory file system contained any output. This PR reads directly from disk while the readonly memory layer is clean, then conservatively restores the overlay after its first mutation so SolutionBuilder can still consume generated reference artifacts. Other write modes and artifact handling remain unchanged.

## Performance

Measured on Node.js v24.12.0 with 2 warmups and 7 interleaved A/B runs per case, comparing `a112746` with this branch:

| Case | Baseline median | Optimized median | Improvement |
| --- | ---: | ---: | ---: |
| react-1k | 1482.9 ms | 1377.1 ms | 7.14% |
| react-5k | 4682.0 ms | 4068.3 ms | 13.11% |
| react-10k | 8302.2 ms | 7199.0 ms | 13.29% |

The optimized build won all 21 paired runs. In the react-5k call profile, `normalizePath` calls fell by 44.6% and `realpathSync` calls fell by 36.1%; the interleaved timings above are the primary performance evidence.

## Validation

- `pnpm lint`
- `pnpm test` (29 files, 163 tests)

## Related Links

- https://github.com/rstackjs/ts-checker-rspack-plugin/pull/134