### PR TITLE
perf: reduce realpath overhead

### DIFF
--- a/src/typescript/worker/lib/file-system/real-file-system.ts
+++ b/src/typescript/worker/lib/file-system/real-file-system.ts
@@ -16,16 +16,16 @@ const realPathCache = new Map<string, string>();
  */
 export const realFileSystem: FileSystem = {
   exists(path: string) {
-    return exists(getRealPath(path));
+    return exists(path);
   },
   readFile(path: string, encoding?: string) {
-    return readFile(getRealPath(path), encoding);
+    return readFile(path, encoding);
   },
   readDir(path: string) {
-    return readDir(getRealPath(path));
+    return readDir(path);
   },
   readStats(path: string) {
-    return readStats(getRealPath(path));
+    return readStats(path);
   },
   realPath(path: string) {
     return getRealPath(path);
@@ -86,7 +86,7 @@ function readFile(path: string, encoding?: string): string | undefined {
     if (stats && stats.isFile()) {
       readFileCache.set(
         normalizedPath,
-        fs.readFileSync(normalizedPath, { encoding: encoding as BufferEncoding }).toString()
+        fs.readFileSync(normalizedPath, { encoding: encoding as BufferEncoding }).toString(),
       );
     } else {
       readFileCache.set(normalizedPath, undefined);
@@ -127,7 +127,7 @@ function getRealPath(path: string) {
       }
 
       if (exists(base)) {
-        const realBase = normalize(fs.realpathSync(base));
+        const realBase = normalize(realpath(base));
 
         // Cache the existing ancestor as well as the requested path. TypeScript
         // probes many non-existent extensions below the same directory during
@@ -143,6 +143,26 @@ function getRealPath(path: string) {
   }
 
   return realPathCache.get(normalizedPath) || normalizedPath;
+}
+
+function fsRealPathHandlingLongPath(path: string): string {
+  return path.length < 260 ? fs.realpathSync.native(path) : fs.realpathSync(path);
+}
+
+// Keep this aligned with TypeScript's Node system implementation:
+// https://github.com/microsoft/TypeScript/pull/50306
+const fsRealpath = fs.realpathSync.native
+  ? process.platform === 'win32'
+    ? fsRealPathHandlingLongPath
+    : fs.realpathSync.native
+  : fs.realpathSync;
+
+function realpath(path: string): string {
+  try {
+    return fsRealpath(path);
+  } catch {
+    return path;
+  }
 }
 
 function createDir(path: string) {

--- a/test/unit/typescript/real-file-system.spec.ts
+++ b/test/unit/typescript/real-file-system.spec.ts
@@ -2,27 +2,31 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { realFileSystem } from 'src/typescript/worker/lib/file-system/real-file-system';
+type RealFileSystemModule = typeof import('src/typescript/worker/lib/file-system/real-file-system');
+
+let realFileSystem: RealFileSystemModule['realFileSystem'];
 
 describe('realFileSystem', () => {
   let temporaryDirectory: string;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'ts-checker-real-fs-'));
-    realFileSystem.clearCache();
+    rs.spyOn(fs.realpathSync, 'native');
+    rs.resetModules();
+    ({ realFileSystem } = await import('src/typescript/worker/lib/file-system/real-file-system'));
   });
 
   afterEach(() => {
     realFileSystem.clearCache();
     fs.rmSync(temporaryDirectory, { recursive: true, force: true });
     rs.restoreAllMocks();
+    rs.resetModules();
   });
 
   it('reuses a cached real path for non-existent siblings', () => {
     const parentDirectory = path.join(temporaryDirectory, 'parent');
     fs.mkdirSync(parentDirectory);
     const realParentDirectory = fs.realpathSync(parentDirectory);
-    const realpathSpy = rs.spyOn(fs, 'realpathSync');
 
     expect(realFileSystem.realPath(path.join(parentDirectory, 'first.ts'))).toBe(
       path.join(realParentDirectory, 'first.ts'),
@@ -31,8 +35,8 @@ describe('realFileSystem', () => {
       path.join(realParentDirectory, 'second.ts'),
     );
 
-    expect(realpathSpy).toHaveBeenCalledTimes(1);
-    expect(realpathSpy).toHaveBeenCalledWith(parentDirectory);
+    expect(fs.realpathSync.native).toHaveBeenCalledTimes(1);
+    expect(fs.realpathSync.native).toHaveBeenCalledWith(parentDirectory);
   });
 
   it('still resolves an existing symlink below a cached parent path', () => {

--- a/test/unit/typescript/real-file-system.spec.ts
+++ b/test/unit/typescript/real-file-system.spec.ts
@@ -4,6 +4,8 @@ import path from 'node:path';
 
 type RealFileSystemModule = typeof import('src/typescript/worker/lib/file-system/real-file-system');
 
+const nativeRealpathSync = fs.realpathSync.native;
+
 let realFileSystem: RealFileSystemModule['realFileSystem'];
 
 describe('realFileSystem', () => {
@@ -26,7 +28,7 @@ describe('realFileSystem', () => {
   it('reuses a cached real path for non-existent siblings', () => {
     const parentDirectory = path.join(temporaryDirectory, 'parent');
     fs.mkdirSync(parentDirectory);
-    const realParentDirectory = fs.realpathSync(parentDirectory);
+    const realParentDirectory = nativeRealpathSync(parentDirectory);
 
     expect(realFileSystem.realPath(path.join(parentDirectory, 'first.ts'))).toBe(
       path.join(realParentDirectory, 'first.ts'),
@@ -53,6 +55,6 @@ describe('realFileSystem', () => {
 
     realFileSystem.realPath(path.join(parentDirectory, 'missing.ts'));
 
-    expect(realFileSystem.realPath(linkedDirectory)).toBe(fs.realpathSync(targetDirectory));
+    expect(realFileSystem.realPath(linkedDirectory)).toBe(nativeRealpathSync(targetDirectory));
   });
 });


### PR DESCRIPTION
## Summary

Filesystem reads currently canonicalize every path through `getRealPath`, even though the underlying Node.js read, stat, and directory APIs already follow symlinks. This change lets ordinary reads use their normalized input directly, keeps explicit and write-side realpath resolution intact, and aligns realpath selection and error handling with TypeScript's Node system implementation, including the Windows long-path fallback.

## Performance

Measured against `37ad056` on Node.js 24.12.0 using isolated `react-1k`, `react-5k`, and `react-10k` cases from build-tools-performance. Each variant used an isolated persistent-cache version with 2 warmups and 7 interleaved measured runs.

| Case | Baseline median | Optimized median | Improvement |
| --- | ---: | ---: | ---: |
| react-1k | 2408.9 ms | 2355.9 ms | 2.20% |
| react-5k | 7266.7 ms | 6392.9 ms | 12.02% |
| react-10k | 12506.7 ms | 11519.6 ms | 7.89% |

The optimized build won 19 of 21 paired runs, including all 14 `react-5k` and `react-10k` runs. A supporting `react-10k` issues-worker CPU profile reduced the recorded worker span from 9.28 s to 5.92 s (36.2%); the interleaved timings above are the primary performance evidence.

## Related Links

- https://github.com/microsoft/TypeScript/pull/50306
- https://github.com/rstackjs/build-tools-performance