### PR TITLE
perf: reuse issue worker dependencies in non-watch builds

### DIFF
--- a/src/hooks/tap-start-to-run-workers.ts
+++ b/src/hooks/tap-start-to-run-workers.ts
@@ -119,6 +119,8 @@ function tapStartToRunWorkers(
               aggregatedFilesChange,
               state.watching,
               config.issue.defaultSeverity,
+              // A single-run build already waits for diagnostics. Returning the
+              // dependency snapshot here avoids starting a second worker process.
               !state.watching,
             );
             if (state.aggregatedFilesChange === aggregatedFilesChange) {
@@ -145,6 +147,8 @@ function tapStartToRunWorkers(
       return;
     }
 
+    // Keep dependency collection independent in watch mode so async diagnostics
+    // can finish after the compilation without delaying dependency registration.
     debug(`Submitting the getDependenciesWorker to the pool, iteration ${iteration}.`);
     state.dependenciesPromise = dependenciesPool.submit(async () => {
       try {

--- a/src/hooks/tap-start-to-run-workers.ts
+++ b/src/hooks/tap-start-to-run-workers.ts
@@ -102,7 +102,7 @@ function tapStartToRunWorkers(
     state.aggregatedFilesChange = aggregatedFilesChange;
 
     // submit one at a time for a single compiler
-    state.issuesPromise = (state.issuesPromise || Promise.resolve())
+    const workerResultPromise = (state.issuesPromise || Promise.resolve())
       // resolve to undefined on error
       .catch(() => undefined)
       .then(() => {
@@ -115,10 +115,11 @@ function tapStartToRunWorkers(
         return issuesPool.submit(async () => {
           try {
             debug(`Running the getIssuesWorker, iteration ${iteration}.`);
-            const issues = await getIssuesWorker(
+            const result = await getIssuesWorker(
               aggregatedFilesChange,
               state.watching,
               config.issue.defaultSeverity,
+              !state.watching,
             );
             if (state.aggregatedFilesChange === aggregatedFilesChange) {
               state.aggregatedFilesChange = undefined;
@@ -126,7 +127,7 @@ function tapStartToRunWorkers(
             if (state.abortController === abortController) {
               state.abortController = undefined;
             }
-            return issues;
+            return result;
           } catch (error) {
             hooks.error.call(error, compilation);
             return undefined;
@@ -135,6 +136,14 @@ function tapStartToRunWorkers(
           }
         }, abortController.signal);
       });
+
+    state.issuesPromise = workerResultPromise.then((result) => result?.issues);
+
+    if (!state.watching) {
+      debug(`Reusing dependencies from the getIssuesWorker, iteration ${iteration}.`);
+      state.dependenciesPromise = workerResultPromise.then((result) => result?.dependencies);
+      return;
+    }
 
     debug(`Submitting the getDependenciesWorker to the pool, iteration ${iteration}.`);
     state.dependenciesPromise = dependenciesPool.submit(async () => {

--- a/src/typescript/worker/get-issues-worker.ts
+++ b/src/typescript/worker/get-issues-worker.ts
@@ -1,4 +1,5 @@
 import type { FilesChange } from '../../files-change';
+import type { FilesMatch } from '../../files-match';
 import type { Issue, IssueDefaultSeverity } from '../../issue';
 import { exposeRpc } from '../../rpc';
 
@@ -29,11 +30,17 @@ import { dumpTracingLegendIfNeeded } from './lib/tracing';
 import { invalidateTsBuildInfo } from './lib/tsbuildinfo';
 import { config } from './lib/worker-config';
 
+interface GetIssuesWorkerResult {
+  issues: Issue[];
+  dependencies?: FilesMatch;
+}
+
 const getIssuesWorker = async (
   change: FilesChange,
   watching: boolean,
   defaultSeverity: IssueDefaultSeverity,
-): Promise<Issue[]> => {
+  withDependencies = false,
+): Promise<GetIssuesWorkerResult> => {
   system.invalidateCache();
 
   if (didConfigFileChanged(change)) {
@@ -66,7 +73,10 @@ const getIssuesWorker = async (
   const parseConfigIssues = getParseConfigIssues(defaultSeverity);
   if (parseConfigIssues.length) {
     // report config parse issues and exit
-    return parseConfigIssues;
+    return {
+      issues: parseConfigIssues,
+      dependencies: withDependencies ? getDependencies() : undefined,
+    };
   }
 
   // use proper implementation based on the config
@@ -96,7 +106,10 @@ const getIssuesWorker = async (
   printPerformanceMeasuresIfNeeded();
   disablePerformanceIfNeeded();
 
-  return issues;
+  return {
+    issues,
+    dependencies: withDependencies ? getDependencies() : undefined,
+  };
 };
 
 exposeRpc(getIssuesWorker);


### PR DESCRIPTION
## Summary

Non-watch builds currently initialize a second TypeScript worker only to collect dependencies. The issues worker has already parsed the same configuration and populated its dependency cache while producing diagnostics, so this PR returns the dependency snapshot with the issue result and reuses it for single-run builds.

Watch mode intentionally keeps the dedicated dependency worker. This preserves independent dependency registration and prevents asynchronous diagnostics from delaying `afterCompile`.

## Performance

The benchmark isolates this change with the five cases in `build-tools-performance`.

| Case | Baseline | This PR | Saved | Improvement |
| --- | ---: | ---: | ---: | ---: |
| `react-1k` | 1,201.2 ms | 1,009.2 ms | 192.0 ms | **16.0%** |
| `react-5k` | 3,357.1 ms | 3,012.0 ms | 345.1 ms | **10.3%** |
| `react-10k` | 5,517.9 ms | 5,133.1 ms | 384.9 ms | **7.0%** |
| `ui-components` | 6,587.2 ms | 6,237.2 ms | 350.0 ms | **5.3%** |
| `popular-libs` | 1,324.9 ms | 1,178.9 ms | 146.1 ms | **11.0%** |
| **5-case sum** | **17,988.4 ms** | **16,570.3 ms** | **1,418.1 ms** | **7.9%** |

These numbers measure plugin worker elapsed/resource cost rather than whole-build wall time. The old workers could overlap in real time, so the table should be read as the reduction in plugin CPU/process-initialization work, not as a claim that end-to-end builds are 7.9% faster.

The stable isolated comparison used the common pre-split baseline commit `dadae0c`; the separately merged path-normalization optimization affects a different code path.
