### PR TITLE
perf: reuse issue worker dependencies in synchronous watch builds

### DIFF
--- a/src/hooks/tap-start-to-run-workers.ts
+++ b/src/hooks/tap-start-to-run-workers.ts
@@ -100,6 +100,7 @@ function tapStartToRunWorkers(
       );
     }
     state.aggregatedFilesChange = aggregatedFilesChange;
+    const reuseIssuesWorkerForDependencies = !state.watching || !config.async;
 
     // submit one at a time for a single compiler
     const workerResultPromise = (state.issuesPromise || Promise.resolve())
@@ -119,9 +120,9 @@ function tapStartToRunWorkers(
               aggregatedFilesChange,
               state.watching,
               config.issue.defaultSeverity,
-              // A single-run build already waits for diagnostics. Returning the
-              // dependency snapshot here avoids starting a second worker process.
-              !state.watching,
+              // Non-watch and synchronous watch builds already wait for diagnostics.
+              // Returning the dependencies here avoids starting a second worker.
+              reuseIssuesWorkerForDependencies,
             );
             if (state.aggregatedFilesChange === aggregatedFilesChange) {
               state.aggregatedFilesChange = undefined;
@@ -141,13 +142,13 @@ function tapStartToRunWorkers(
 
     state.issuesPromise = workerResultPromise.then((result) => result?.issues);
 
-    if (!state.watching) {
+    if (reuseIssuesWorkerForDependencies) {
       debug(`Reusing dependencies from the getIssuesWorker, iteration ${iteration}.`);
       state.dependenciesPromise = workerResultPromise.then((result) => result?.dependencies);
       return;
     }
 
-    // Keep dependency collection independent in watch mode so async diagnostics
+    // Keep dependency collection independent in async watch mode so diagnostics
     // can finish after the compilation without delaying dependency registration.
     debug(`Submitting the getDependenciesWorker to the pool, iteration ${iteration}.`);
     state.dependenciesPromise = dependenciesPool.submit(async () => {


### PR DESCRIPTION
## Summary

Synchronous watch builds (`async: false`) already wait for diagnostics, so this PR reuses the dependency snapshot returned by the issues worker instead of starting a dedicated dependency worker. Asynchronous watch builds remain unchanged to preserve non-blocking diagnostics.

## Performance

Measured across the five `build-tools-performance` cases using 5 interleaved rounds and medians:

- worker processes: 2 → 1
- combined peak worker RSS: 5,030.8 → 4,427.9 MiB (**-12.0%**), saving 116–126 MiB per case
- cold worker CPU: 27,852.5 → 27,479.5 ms (**-1.3%**)

Incremental rebuild throughput remained within measurement variance, so the primary benefit is lower memory usage and one fewer long-lived process.

## Related Links

- https://github.com/rstackjs/ts-checker-rspack-plugin/pull/139
