### PR TITLE
fix: watch TypeScript root files with tsgo

### DIFF
--- a/src/hooks/tap-start-to-run-type-script-go.ts
+++ b/src/hooks/tap-start-to-run-type-script-go.ts
@@ -2,6 +2,7 @@ import type * as rspack from '@rspack/core';
 
 import type { FilesChange } from '../files-change';
 import { aggregateFilesChanges, consumeFilesChange } from '../files-change';
+import type { FilesMatch } from '../files-match';
 import { getInfrastructureLogger } from '../infrastructure-logger';
 import type { TsCheckerRspackPluginConfig } from '../plugin-config';
 import { getPluginHooks } from '../plugin-hooks';
@@ -12,6 +13,7 @@ import {
   getTypeScriptGoDependencies,
   isTypeScriptGoStatsError,
   runTypeScriptGo,
+  shouldRefreshTypeScriptGoDependencies,
 } from '../typescript/type-script-go-runner';
 
 import { interceptDoneToGetDevServerTap } from './intercept-done-to-get-dev-server-tap';
@@ -51,6 +53,8 @@ function tapStartToRunTypeScriptGo(
   const hooks = getPluginHooks(compiler);
   const { log, debug } = getInfrastructureLogger(compiler);
   let assertTypeScriptGoExecutablePromise: Promise<void> | undefined;
+  let dependenciesPromise: Promise<FilesMatch> | undefined;
+  let dependenciesCacheGeneration = 0;
 
   const assertTypeScriptGoExecutableOnce = async () => {
     try {
@@ -186,9 +190,38 @@ function tapStartToRunTypeScriptGo(
       log('Calling tsgo for single check.');
     }
 
-    state.dependenciesPromise = Promise.resolve(getTypeScriptGoDependencies(config.typescript));
+    const cacheGeneration = ++dependenciesCacheGeneration;
+    const startPromise = hooks.start.promise(filesChange, compilation);
+    state.dependenciesPromise = startPromise.then((nextFilesChange) => {
+      if (cacheGeneration !== dependenciesCacheGeneration) {
+        return undefined;
+      }
 
-    filesChange = await hooks.start.promise(filesChange, compilation);
+      if (
+        state.watching &&
+        dependenciesPromise &&
+        !shouldRefreshTypeScriptGoDependencies(
+          state.lastDependencies,
+          nextFilesChange,
+        )
+      ) {
+        debug(`Reusing cached tsgo dependencies, iteration ${iteration}.`);
+        return dependenciesPromise;
+      }
+
+      const nextDependenciesPromise = getTypeScriptGoDependencies(config.typescript);
+      if (state.watching) {
+        dependenciesPromise = nextDependenciesPromise;
+        void nextDependenciesPromise.catch(() => {
+          if (dependenciesPromise === nextDependenciesPromise) {
+            dependenciesPromise = undefined;
+          }
+        });
+      }
+      return nextDependenciesPromise;
+    });
+
+    filesChange = await startPromise;
     let aggregatedFilesChange = filesChange;
     if (state.aggregatedFilesChange) {
       aggregatedFilesChange = aggregateFilesChanges([aggregatedFilesChange, filesChange]);
@@ -244,9 +277,15 @@ function tapStartToRunTypeScriptGo(
     }
   };
 
-  compiler.hooks.watchClose.tap('TsCheckerRspackPlugin', abortTypeScriptGo);
+  compiler.hooks.watchClose.tap('TsCheckerRspackPlugin', () => {
+    dependenciesCacheGeneration++;
+    dependenciesPromise = undefined;
+    abortTypeScriptGo();
+  });
 
   compiler.hooks.failed.tap('TsCheckerRspackPlugin', () => {
+    dependenciesCacheGeneration++;
+    dependenciesPromise = undefined;
     if (!state.watching) {
       abortTypeScriptGo();
     }

--- a/src/typescript/type-script-go-runner.ts
+++ b/src/typescript/type-script-go-runner.ts
@@ -1,11 +1,15 @@
-import { spawn } from 'node:child_process';
+import { execFile, spawn } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { promisify } from 'node:util';
 
+import type { FilesChange } from '../files-change';
+import type { FilesMatch } from '../files-match';
 import type { Issue, IssueDefaultSeverity } from '../issue';
 import type { Logger } from '../logger';
 import { AbortError } from '../utils/async/abort-error';
+import { isInsideAnotherPath } from '../utils/path/is-inside-another-path';
 
 import type { TypeScriptWorkerConfig } from './type-script-worker-config';
 import {
@@ -18,6 +22,12 @@ import {
 type TypeScriptGoExecutable = {
   command: string;
   args: string[];
+};
+
+type TypeScriptGoShowConfig = {
+  exclude?: string[];
+  files?: string[];
+  references?: { path?: string }[];
 };
 
 function resolveTypeScriptGoPackageJsonPath(config: TypeScriptWorkerConfig): string {
@@ -82,6 +92,66 @@ async function resolveTypeScriptGoExecutable(
     command: binPath,
     args: [],
   };
+}
+
+async function runTypeScriptGoShowConfig(
+  executable: TypeScriptGoExecutable,
+  configFile: string,
+): Promise<TypeScriptGoShowConfig> {
+  // TS 7's JavaScript config API is still unstable. The stable CLI exposes the
+  // resolved root file list and project references through --showConfig.
+  const { stdout } = await promisify(execFile)(
+    executable.command,
+    [
+      ...executable.args,
+      '--project',
+      configFile,
+      '--showConfig',
+      '--pretty',
+      'false',
+    ],
+    {
+      cwd: path.dirname(configFile),
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+    },
+  );
+
+  const parsedConfig: unknown = JSON.parse(stdout);
+  if (!parsedConfig || typeof parsedConfig !== 'object' || Array.isArray(parsedConfig)) {
+    throw new TypeError('Invalid tsgo --showConfig output.');
+  }
+
+  return parsedConfig as TypeScriptGoShowConfig;
+}
+
+function toComparisonPath(file: string): string {
+  const normalizedPath = path.normalize(file);
+  return process.platform === 'win32' ? normalizedPath.toLowerCase() : normalizedPath;
+}
+
+function shouldRefreshTypeScriptGoDependencies(
+  dependencies: FilesMatch | undefined,
+  { changedFiles = [], deletedFiles = [] }: FilesChange,
+): boolean {
+  if (!dependencies) {
+    return true;
+  }
+
+  const dependencyKeys = dependencies.files.map(toComparisonPath);
+
+  return (
+    changedFiles.some((file) => {
+      const key = toComparisonPath(file);
+      const extension = path.extname(file).toLowerCase();
+      return (
+        extension === '.json' ||
+        (dependencies.extensions.includes(extension) &&
+          !dependencyKeys.includes(key))
+      );
+    }) ||
+    deletedFiles.some((file) => dependencyKeys.includes(toComparisonPath(file)))
+  );
 }
 
 function createTypeScriptGoArgs(config: TypeScriptWorkerConfig) {
@@ -334,17 +404,92 @@ async function runTypeScriptGo(
   });
 }
 
-function getTypeScriptGoDependencies(config: TypeScriptWorkerConfig): {
-  files: string[];
-  dirs: string[];
-  excluded: string[];
-  extensions: string[];
-} {
+async function getTypeScriptGoDependencies(
+  config: TypeScriptWorkerConfig,
+): Promise<FilesMatch> {
+  const executable = await resolveTypeScriptGoExecutable(config);
+  const files = new Set<string>();
+  const dirs = new Set<string>();
+  const excluded = new Set<string>();
+  const visitedConfigs = new Set<string>();
+
+  const collectConfigDependencies = async (
+    configFile: string,
+    fallbackRoot: string,
+    collectExcluded: boolean,
+  ): Promise<void> => {
+    const normalizedConfigFile = path.normalize(configFile);
+    const configKey = toComparisonPath(normalizedConfigFile);
+    if (visitedConfigs.has(configKey)) {
+      return;
+    }
+    visitedConfigs.add(configKey);
+
+    const configDir = path.dirname(normalizedConfigFile);
+    const normalizedRoot = path.normalize(fallbackRoot);
+    files.add(normalizedConfigFile);
+    if (
+      !Array.from(dirs).some(
+        (dir) =>
+          path.relative(dir, normalizedRoot) === '' ||
+          isInsideAnotherPath(dir, normalizedRoot),
+      )
+    ) {
+      dirs.add(normalizedRoot);
+    }
+    excluded.add(path.join(normalizedRoot, 'node_modules'));
+
+    let parsedConfig: TypeScriptGoShowConfig | undefined;
+    try {
+      parsedConfig = await runTypeScriptGoShowConfig(executable, normalizedConfigFile);
+    } catch {
+      return;
+    }
+
+    // Equivalent to parsedConfig.fileNames in the TypeScript 6 code path.
+    for (const file of parsedConfig.files || []) {
+      files.add(path.normalize(path.resolve(configDir, file)));
+    }
+
+    if (collectExcluded) {
+      for (const exclude of parsedConfig.exclude || []) {
+        excluded.add(path.normalize(path.resolve(configDir, exclude)));
+      }
+    }
+
+    for (const reference of parsedConfig.references || []) {
+      if (reference.path) {
+        const resolvedReference = path.resolve(configDir, reference.path);
+        const referenceConfig =
+          path.extname(resolvedReference).toLowerCase() === '.json'
+            ? resolvedReference
+            : path.join(resolvedReference, 'tsconfig.json');
+        await collectConfigDependencies(
+          referenceConfig,
+          path.dirname(referenceConfig),
+          false,
+        );
+      }
+    }
+  };
+
+  await collectConfigDependencies(config.configFile, config.context, true);
+
   return {
-    files: [config.configFile],
-    dirs: [config.context],
-    excluded: [path.join(config.context, 'node_modules')],
-    extensions: ['.ts', '.tsx', '.mts', '.cts', '.js', '.jsx', '.mjs', '.cjs', '.json'],
+    files: Array.from(files),
+    dirs: Array.from(dirs),
+    excluded: Array.from(excluded),
+    extensions: [
+      '.ts',
+      '.tsx',
+      '.mts',
+      '.cts',
+      '.js',
+      '.jsx',
+      '.mjs',
+      '.cjs',
+      '.json',
+    ],
   };
 }
 
@@ -360,4 +505,5 @@ export {
   resolveTypeScriptGoBinPath,
   resolveTypeScriptGoPackageJsonPath,
   runTypeScriptGo,
+  shouldRefreshTypeScriptGoDependencies,
 };

--- a/src/typescript/type-script-go-runner.ts
+++ b/src/typescript/type-script-go-runner.ts
@@ -451,7 +451,7 @@ async function getTypeScriptGoDependencies(
       files.add(path.normalize(path.resolve(configDir, file)));
     }
 
-    if (collectExcluded) {
+    if (collectExcluded && !parsedConfig.references?.length) {
       for (const exclude of parsedConfig.exclude || []) {
         excluded.add(path.normalize(path.resolve(configDir, exclude)));
       }

--- a/test/e2e/with-rspack/watch.test.ts
+++ b/test/e2e/with-rspack/watch.test.ts
@@ -116,6 +116,63 @@ test.each([{ async: false }, { async: true }])(
   20_000,
 );
 
+test(
+  'adds tsgo root files to watch dependencies',
+  async () => {
+    const fixture = await createFixture('basic');
+    await fixture.write(
+      'src/unbundled.ts',
+      'export const unbundled: number = 1;\n',
+    );
+
+    const compiler = createCompiler(
+      createRspackConfig(
+        fixture.root,
+        new TsCheckerRspackPlugin({
+          async: false,
+          typescript: { tsgo: true },
+        }),
+      ),
+    );
+    const recorder = recordCompiler(compiler);
+    const { watching, fatalErrors } = watchCompiler(compiler);
+
+    try {
+      await waitForInitialCompilation(recorder);
+      expect(
+        recorder.builds[0]?.compilation.fileDependencies.has(
+          fixture.path('src/unbundled.ts'),
+        ),
+      ).toBe(true);
+
+      const issueEventIndex = recorder.issueEvents.length;
+      const buildIndex = recorder.builds.length;
+      await fixture.replace(
+        'src/unbundled.ts',
+        'unbundled: number = 1',
+        "unbundled: number = 'invalid'",
+      );
+      await recorder.waitForBuildAndIssueEventAfter(
+        buildIndex,
+        issueEventIndex,
+        (event) =>
+          Boolean(
+            event.change?.changedFiles.some((file) =>
+              file.replaceAll('\\', '/').endsWith('/src/unbundled.ts'),
+            ) && event.issues.some((issue) => issue.code === 'TS2322'),
+          ),
+      );
+
+      expect(fatalErrors).toEqual([]);
+      expect(recorder.workerErrors).toEqual([]);
+    } finally {
+      await closeWatching(watching);
+      await fixture.cleanup();
+    }
+  },
+  35_000,
+);
+
 test.each([{ async: false }, { async: true }])(
   'ignores package.json in incremental TypeScript changes when async is $async',
   async ({ async }) => {

--- a/test/unit/typescript/type-script-go-runner.spec.ts
+++ b/test/unit/typescript/type-script-go-runner.spec.ts
@@ -157,6 +157,7 @@ describe('typescript/type-script-go-runner', () => {
     fs.writeFileSync(
       configFile,
       JSON.stringify({
+        exclude: ['packages'],
         files: [],
         references: [{ path: './packages/child' }],
       }),

--- a/test/unit/typescript/type-script-go-runner.spec.ts
+++ b/test/unit/typescript/type-script-go-runner.spec.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -6,6 +7,12 @@ import type { TypeScriptWorkerConfig } from 'src/typescript/type-script-worker-c
 
 describe('typescript/type-script-go-runner', () => {
   const tsgoPackageJsonPath = require.resolve('@typescript/native-preview/package.json');
+  const requireFromTypeScript7Example = createRequire(
+    path.resolve('examples/typescript-7/package.json'),
+  );
+  const typeScript7PackageJsonPath = requireFromTypeScript7Example.resolve(
+    'typescript/package.json',
+  );
   const projectContext = path.resolve('project');
   const config: TypeScriptWorkerConfig = {
     enabled: true,
@@ -87,15 +94,129 @@ describe('typescript/type-script-go-runner', () => {
     ]);
   });
 
-  it('creates coarse watcher dependencies without parsing tsconfig', async () => {
+  it('collects root files from tsgo showConfig', async () => {
+    const projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'ts-checker-tsgo-project-'));
+    const srcPath = path.join(projectPath, 'src');
+    const configFile = path.join(projectPath, 'tsconfig.json');
+    tempDirs.push(projectPath);
+    fs.mkdirSync(srcPath, { recursive: true });
+    fs.writeFileSync(path.join(srcPath, 'index.ts'), 'export const value = 1;\n');
+    fs.writeFileSync(path.join(srcPath, 'excluded.ts'), 'export const excluded = 3;\n');
+    fs.writeFileSync(
+      configFile,
+      JSON.stringify({ include: ['src'], exclude: ['src/excluded.ts'] }),
+    );
+    const { getTypeScriptGoDependencies } = await import('src/typescript/type-script-go-runner');
+    const typeScript7Config = {
+      ...config,
+      configFile,
+      context: projectPath,
+      typescriptPath: typeScript7PackageJsonPath,
+      tsgoPackage: 'typescript' as const,
+    };
+    const extensions = [
+      '.ts',
+      '.tsx',
+      '.mts',
+      '.cts',
+      '.js',
+      '.jsx',
+      '.mjs',
+      '.cjs',
+      '.json',
+    ];
+
+    const dependencies = await getTypeScriptGoDependencies(typeScript7Config);
+
+    expect(new Set(dependencies.files)).toEqual(
+      new Set([configFile, path.join(srcPath, 'index.ts')]),
+    );
+    expect(dependencies.dirs).toEqual([projectPath]);
+    expect(new Set(dependencies.excluded)).toEqual(
+      new Set([
+        path.join(projectPath, 'node_modules'),
+        path.join(srcPath, 'excluded.ts'),
+      ]),
+    );
+    expect(dependencies.extensions).toEqual(extensions);
+  });
+
+  it('collects files from project references', async () => {
+    const workspacePath = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'ts-checker-tsgo-solution-'),
+    );
+    const projectPath = path.join(workspacePath, 'root');
+    const childPath = path.join(projectPath, 'packages/child');
+    const childSrcPath = path.join(childPath, 'src');
+    const configFile = path.join(projectPath, 'tsconfig.json');
+    const childConfigFile = path.join(childPath, 'tsconfig.json');
+    const childFile = path.join(childSrcPath, 'index.ts');
+    tempDirs.push(workspacePath);
+    fs.mkdirSync(projectPath, { recursive: true });
+    fs.mkdirSync(childSrcPath, { recursive: true });
+    fs.writeFileSync(
+      configFile,
+      JSON.stringify({
+        files: [],
+        references: [{ path: './packages/child' }],
+      }),
+    );
+    fs.writeFileSync(childConfigFile, JSON.stringify({ include: ['src'] }));
+    fs.writeFileSync(childFile, 'export const child = 1;\n');
     const { getTypeScriptGoDependencies } = await import('src/typescript/type-script-go-runner');
 
-    expect(getTypeScriptGoDependencies(config)).toEqual({
-      files: [config.configFile],
-      dirs: [config.context],
-      excluded: [path.join(config.context, 'node_modules')],
-      extensions: ['.ts', '.tsx', '.mts', '.cts', '.js', '.jsx', '.mjs', '.cjs', '.json'],
+    const dependencies = await getTypeScriptGoDependencies({
+      ...config,
+      build: true,
+      configFile,
+      context: projectPath,
+      typescriptPath: typeScript7PackageJsonPath,
+      tsgoPackage: 'typescript',
     });
+
+    expect(new Set(dependencies.files)).toEqual(
+      new Set([configFile, childConfigFile, childFile]),
+    );
+    expect(dependencies.dirs).toEqual([projectPath]);
+    expect(new Set(dependencies.excluded)).toEqual(
+      new Set([
+        path.join(projectPath, 'node_modules'),
+        path.join(childPath, 'node_modules'),
+      ]),
+    );
+  });
+
+  it('refreshes cached dependencies when the file list may change', async () => {
+    const configFile = path.join(projectContext, 'tsconfig.json');
+    const knownFile = path.join(projectContext, 'src/index.ts');
+    const referencedConfigFile = path.join(projectContext, 'packages/app/tsconfig.json');
+    const dependencies = {
+      files: [configFile, knownFile, referencedConfigFile],
+      dirs: [projectContext],
+      excluded: [],
+      extensions: ['.ts'],
+    };
+    const { shouldRefreshTypeScriptGoDependencies } =
+      await import('src/typescript/type-script-go-runner');
+
+    expect([
+      shouldRefreshTypeScriptGoDependencies(undefined, {}),
+      shouldRefreshTypeScriptGoDependencies(dependencies, {
+        changedFiles: [knownFile],
+      }),
+      shouldRefreshTypeScriptGoDependencies(dependencies, {
+        changedFiles: [referencedConfigFile],
+      }),
+      shouldRefreshTypeScriptGoDependencies(dependencies, {
+        changedFiles: [path.join(projectContext, 'src/new.ts')],
+      }),
+      shouldRefreshTypeScriptGoDependencies(dependencies, {
+        deletedFiles: [knownFile],
+      }),
+      shouldRefreshTypeScriptGoDependencies(dependencies, {
+        changedFiles: [path.join(projectContext, 'src/style.css')],
+      }),
+    ]).toEqual([true, false, true, true, true, false]);
   });
 
   it('resolves the tsgo package from an absolute package.json path', async () => {


### PR DESCRIPTION
## Summary

The tsgo path only registered the TypeScript config and a coarse directory watcher, so changes to existing root files outside the Rspack module graph did not trigger another type check. This resolves root files and project references through `tsgo --showConfig`, registers them as compilation dependencies, and reuses the resolved dependencies during watch rebuilds.

## Related Links

Fixes web-infra-dev/rsbuild#8232