### PR TITLE
test: stabilize tsgo root file watch regression

### DIFF
--- a/test/e2e/with-rspack/watch.test.ts
+++ b/test/e2e/with-rspack/watch.test.ts
@@ -117,7 +117,7 @@ test.each([{ async: false }, { async: true }])(
 );
 
 test(
-  'adds tsgo root files to watch dependencies',
+  'rebuilds when an unbundled tsgo root file changes',
   async () => {
     const fixture = await createFixture('basic');
     await fixture.write(
@@ -139,11 +139,6 @@ test(
 
     try {
       await waitForInitialCompilation(recorder);
-      expect(
-        recorder.builds[0]?.compilation.fileDependencies.has(
-          fixture.path('src/unbundled.ts'),
-        ),
-      ).toBe(true);
 
       const issueEventIndex = recorder.issueEvents.length;
       const buildIndex = recorder.builds.length;


### PR DESCRIPTION
## Summary

The tsgo root-file watch regression test asserted Rspack's internal dependency collection from the first recorded build, which flaked twice on macOS even though the test already waits for correlated build and issue events. This removes the redundant internal assertion and keeps the user-visible contract: changing an unbundled TypeScript root file must trigger a correlated rebuild and report the expected diagnostic.

## Related Links

https://github.com/rstackjs/ts-checker-rspack-plugin/actions/runs/31557477063/job/93996308486