### PR TITLE
chore: align VS Code configuration with Rstack

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "search.useIgnoreFiles": true,
+  "editor.defaultFormatter": "rstack.rstack"
+}


### PR DESCRIPTION
VS Code does not use Rstack as the repository-wide default formatter. Align the shared editor settings with rsbuild-plugin-template.